### PR TITLE
JailbreakDetect - определение root на устройстве. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pod 'Surf-Utils/$UTIL_NAME$' :git => "https://github.com/surfstudio/iOS-Utils.gi
 ## Список утилит
 
 - [StringAttributes](#stringattributes) - упрощение работы с `NSAttributedString`
+- [JailbreakDetect](#jailbreakdetect) - позволяет определить наличие root на девайсе.
 
 
 ## Утилиты
@@ -28,6 +29,20 @@ pod 'Surf-Utils/$UTIL_NAME$' :git => "https://github.com/surfstudio/iOS-Utils.gi
 ```Swift
 let attrString = "Awesome attributed srting".with(attributes: [.kern(9), lineHeight(20)])
 ```
+
+### JailbreakDetect
+
+Утилита позволяет определить наличие root на устройстве. 
+
+Пример:
+```Swift
+if JailbreakDetect.isJailBroken() {
+    print("На девайсе установлен jailbreak")
+} else {
+    print("Девайс чист")
+}
+```
+
 ## Версионирование
 
 В качестве принципа версионирования используется [Семантическое версионирования (Semantic Versioning)](https://semver.org/).

--- a/Surf-Utils.podspec
+++ b/Surf-Utils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "Surf-Utils"
-  s.version = "0.0.2"
+  s.version = "1.0.2"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:
@@ -18,6 +18,11 @@ Pod::Spec.new do |s|
   s.subspec 'StringAttributes' do |sp|
     sp.source_files = 'Utils/Utils/String/String+Attributes.swift'
     sp.framework = 'Foundation', 'UIKit'
+  end
+
+  s.subspec 'JailbreakDetect' do |sp|
+    sp.source_files = 'Utils/Utils/JailbreakDetect/JailbreakDetect.swift'
+    sp.framework = 'Foundation'
   end
 
 end

--- a/Utils/Utils.xcodeproj/project.pbxproj
+++ b/Utils/Utils.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4F3ED9EE211C27CF0030DD45 /* UtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F3ED9ED211C27CF0030DD45 /* UtilsTests.swift */; };
 		4F3ED9F0211C27CF0030DD45 /* Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F3ED9E2211C27CF0030DD45 /* Utils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F3ED9FC211C27FD0030DD45 /* String+Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F3ED9FB211C27FD0030DD45 /* String+Attributes.swift */; };
+		80437D26214045EF0095A8D0 /* JailbreakDetect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80437D25214045EF0095A8D0 /* JailbreakDetect.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,6 +32,7 @@
 		4F3ED9ED211C27CF0030DD45 /* UtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsTests.swift; sourceTree = "<group>"; };
 		4F3ED9EF211C27CF0030DD45 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4F3ED9FB211C27FD0030DD45 /* String+Attributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Attributes.swift"; sourceTree = "<group>"; };
+		80437D25214045EF0095A8D0 /* JailbreakDetect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JailbreakDetect.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +75,7 @@
 		4F3ED9E1211C27CF0030DD45 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				80437D24214045B30095A8D0 /* JailbreakDetect */,
 				4F3ED9FA211C27E80030DD45 /* String */,
 				4F3ED9E2211C27CF0030DD45 /* Utils.h */,
 				4F3ED9E3211C27CF0030DD45 /* Info.plist */,
@@ -95,6 +98,14 @@
 				4F3ED9FB211C27FD0030DD45 /* String+Attributes.swift */,
 			);
 			path = String;
+			sourceTree = "<group>";
+		};
+		80437D24214045B30095A8D0 /* JailbreakDetect */ = {
+			isa = PBXGroup;
+			children = (
+				80437D25214045EF0095A8D0 /* JailbreakDetect.swift */,
+			);
+			path = JailbreakDetect;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -206,6 +217,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				80437D26214045EF0095A8D0 /* JailbreakDetect.swift in Sources */,
 				4F3ED9FC211C27FD0030DD45 /* String+Attributes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Utils/Utils/JailbreakDetect/JailbreakDetect.swift
+++ b/Utils/Utils/JailbreakDetect/JailbreakDetect.swift
@@ -1,0 +1,45 @@
+//
+//  JailbreakDetect.swift
+//  Utils
+//
+//  Created by Vlad Krupenko on 05.09.2018.
+//  Copyright © 2018 Surf. All rights reserved.
+//
+
+import Foundation
+
+final class JailbreakDetect {
+
+    /// Method return true, if we can detect some common for jailbroken deivce files or can write to device
+    static func isJailBroken() -> Bool {
+        // Check 1 : existence of files that are common for jailbroken devices
+        if FileManager.default.fileExists(atPath: "/Applications/Cydia.app")
+            || FileManager.default.fileExists(atPath: "/Library/MobileSubstrate/MobileSubstrate.dylib")
+            || FileManager.default.fileExists(atPath: "/bin/bash")
+            || FileManager.default.fileExists(atPath: "/usr/sbin/sshd")
+            || FileManager.default.fileExists(atPath: "/etc/apt")
+            || FileManager.default.fileExists(atPath: "/private/var/lib/apt/")
+            || canOpenCydia() {
+            return true
+        }
+
+        // Check 2 : Reading and writing in system directories (sandbox violation)
+        let stringToWrite = "Jailbreak Test"
+        do {
+            try stringToWrite.write(toFile: "/private/JailbreakTest.txt", atomically: true, encoding: String.Encoding.utf8)
+            //Device is jailbroken
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Method will return true if we can open cydia package
+    private static func canOpenCydia() -> Bool {
+        guard let cydiaURL = URL(string: "cydia://package/com.example.package") else {
+            return false
+        }
+        return UIApplication.shared.canOpenURL(cydiaURL)
+    }
+
+}


### PR DESCRIPTION
Теги: New
Описание: Утилита позволяет определить взломано ли устройство, удалось ли получить на нем root и возможно установлен jailbreak. По факут простой булевый метод. Используется внутри проектов surf.