### PR TITLE
added VibrationFeedbackManager to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/surfstudio/iOS-Utils.svg?branch=master)](https://travis-ci.org/surfstudio/iOS-Utils)
 # iOS-Utils
 
-Этот репозиторий содержит коллекцию утилит, каждая из которых находится в отдельной `pod subspec`. 
+Этот репозиторий содержит коллекцию утилит, каждая из которых находится в отдельной `pod subspec`.
 Обновление версии любой утилиты означает обновление версии всего репозитория.
 
 ## Как установить
@@ -17,6 +17,7 @@ pod 'Surf-Utils/$UTIL_NAME$' :git => "https://github.com/surfstudio/iOS-Utils.gi
 
 - [StringAttributes](#stringattributes) - упрощение работы с `NSAttributedString`
 - [JailbreakDetect](#jailbreakdetect) - позволяет определить наличие root на девайсе.
+- [JailbreakDetect](#vibrationfeedbackmanager) - позволяет воспроизвести вибрацию на устройстве.
 
 
 ## Утилиты
@@ -32,7 +33,7 @@ let attrString = "Awesome attributed srting".with(attributes: [.kern(9), lineHei
 
 ### JailbreakDetect
 
-Утилита позволяет определить наличие root на устройстве. 
+Утилита позволяет определить наличие root на устройстве.
 
 Пример:
 ```Swift
@@ -42,6 +43,17 @@ if JailbreakDetect.isJailBroken() {
     print("Девайс чист")
 }
 ```
+
+### VibrationFeedbackManager
+
+Утилита для воспроизведения вибраций с поддержкой taptic engine (1.0/2.0). Автоматически определяет тип девайса и вызывает корректный тип вибрации.
+
+Пример:
+```Swift
+/// воспроизвести вибрацию по событию error
+VibrationFeedbackManager.playVibrationFeedbackBy(event: .error)
+```
+
 
 ## Версионирование
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pod 'Surf-Utils/$UTIL_NAME$' :git => "https://github.com/surfstudio/iOS-Utils.gi
 
 - [StringAttributes](#stringattributes) - упрощение работы с `NSAttributedString`
 - [JailbreakDetect](#jailbreakdetect) - позволяет определить наличие root на девайсе.
-- [JailbreakDetect](#vibrationfeedbackmanager) - позволяет воспроизвести вибрацию на устройстве.
+- [VibrationFeedbackManager](#vibrationfeedbackmanager) - позволяет воспроизвести вибрацию на устройстве.
 
 
 ## Утилиты

--- a/Surf-Utils.podspec
+++ b/Surf-Utils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "Surf-Utils"
-  s.version = "1.0.4"
+  s.version = "2.0.4"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:
@@ -23,6 +23,12 @@ Pod::Spec.new do |s|
   s.subspec 'JailbreakDetect' do |sp|
     sp.source_files = 'Utils/Utils/JailbreakDetect/JailbreakDetect.swift'
     sp.framework = 'Foundation'
+  end
+
+  s.subspec 'VibrationFeedbackManager' do |sp|
+    sp.source_files = 'Utils/Utils/VibrationFeedbackManager/*.swift'
+    sp.framework = 'AudioToolbox'
+    sp.dependency 'Device.swift'
   end
 
 end

--- a/Surf-Utils.podspec
+++ b/Surf-Utils.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   s.subspec 'VibrationFeedbackManager' do |sp|
     sp.source_files = 'Utils/Utils/VibrationFeedbackManager/*.swift'
     sp.framework = 'AudioToolbox'
-    sp.dependency 'Device.swift'
   end
 
 end

--- a/Utils/Utils.xcodeproj/project.pbxproj
+++ b/Utils/Utils.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		E9B0630A2146924A0080C391 /* VibrationFeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */; };
 		E9B0630C214692C30080C391 /* UIDevice+hasTapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */; };
 		E9B0630E214693160080C391 /* UIDevice+hasHapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */; };
+		E9B063102147AECC0080C391 /* UIDevice+feedbackType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B0630F2147AECC0080C391 /* UIDevice+feedbackType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +40,7 @@
 		E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrationFeedbackManager.swift; sourceTree = "<group>"; };
 		E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+hasTapticEngine.swift"; sourceTree = "<group>"; };
 		E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+hasHapticFeedback.swift"; sourceTree = "<group>"; };
+		E9B0630F2147AECC0080C391 /* UIDevice+feedbackType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+feedbackType.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,6 +123,7 @@
 				E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */,
 				E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */,
 				E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */,
+				E9B0630F2147AECC0080C391 /* UIDevice+feedbackType.swift */,
 			);
 			path = VibrationFeedbackManager;
 			sourceTree = "<group>";
@@ -234,6 +237,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E9B063102147AECC0080C391 /* UIDevice+feedbackType.swift in Sources */,
 				E9B0630A2146924A0080C391 /* VibrationFeedbackManager.swift in Sources */,
 				E9B0630C214692C30080C391 /* UIDevice+hasTapticEngine.swift in Sources */,
 				80437D26214045EF0095A8D0 /* JailbreakDetect.swift in Sources */,

--- a/Utils/Utils.xcodeproj/project.pbxproj
+++ b/Utils/Utils.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		4F3ED9F0211C27CF0030DD45 /* Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F3ED9E2211C27CF0030DD45 /* Utils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F3ED9FC211C27FD0030DD45 /* String+Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F3ED9FB211C27FD0030DD45 /* String+Attributes.swift */; };
 		80437D26214045EF0095A8D0 /* JailbreakDetect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80437D25214045EF0095A8D0 /* JailbreakDetect.swift */; };
+		E9B0630A2146924A0080C391 /* VibrationFeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */; };
+		E9B0630C214692C30080C391 /* UIDevice+hasTapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */; };
+		E9B0630E214693160080C391 /* UIDevice+hasHapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -33,6 +36,9 @@
 		4F3ED9EF211C27CF0030DD45 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4F3ED9FB211C27FD0030DD45 /* String+Attributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Attributes.swift"; sourceTree = "<group>"; };
 		80437D25214045EF0095A8D0 /* JailbreakDetect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JailbreakDetect.swift; sourceTree = "<group>"; };
+		E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrationFeedbackManager.swift; sourceTree = "<group>"; };
+		E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+hasTapticEngine.swift"; sourceTree = "<group>"; };
+		E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+hasHapticFeedback.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +81,7 @@
 		4F3ED9E1211C27CF0030DD45 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				E9B06306214691F30080C391 /* VibrationFeedbackManager */,
 				80437D24214045B30095A8D0 /* JailbreakDetect */,
 				4F3ED9FA211C27E80030DD45 /* String */,
 				4F3ED9E2211C27CF0030DD45 /* Utils.h */,
@@ -106,6 +113,16 @@
 				80437D25214045EF0095A8D0 /* JailbreakDetect.swift */,
 			);
 			path = JailbreakDetect;
+			sourceTree = "<group>";
+		};
+		E9B06306214691F30080C391 /* VibrationFeedbackManager */ = {
+			isa = PBXGroup;
+			children = (
+				E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */,
+				E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */,
+				E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */,
+			);
+			path = VibrationFeedbackManager;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -217,7 +234,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E9B0630A2146924A0080C391 /* VibrationFeedbackManager.swift in Sources */,
+				E9B0630C214692C30080C391 /* UIDevice+hasTapticEngine.swift in Sources */,
 				80437D26214045EF0095A8D0 /* JailbreakDetect.swift in Sources */,
+				E9B0630E214693160080C391 /* UIDevice+hasHapticFeedback.swift in Sources */,
 				4F3ED9FC211C27FD0030DD45 /* String+Attributes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Utils/Utils/VibrationFeedbackManager/UIDevice+feedbackType.swift
+++ b/Utils/Utils/VibrationFeedbackManager/UIDevice+feedbackType.swift
@@ -1,0 +1,22 @@
+//
+//  UIDevice+feedbackType.swift
+//  Utils
+//
+//  Created by Pavel Marinchenko on 9/11/18.
+//  Copyright © 2018 Surf. All rights reserved.
+//
+
+extension UIDevice {
+    enum FeedbackType: Int {
+        case base = 0
+        case taptic
+        case haptic
+    }
+
+    var feedbackType: FeedbackType {
+        if let fsl = UIDevice.current.value(forKey: "_feedbackSupportLevel") as? Int, let feedbackSupportLevel = Int(fsl) {
+            return FeedbackType(rawValue: feedbackSupportLevel) ?? .base
+        }
+        return .base
+    }
+}

--- a/Utils/Utils/VibrationFeedbackManager/UIDevice+feedbackType.swift
+++ b/Utils/Utils/VibrationFeedbackManager/UIDevice+feedbackType.swift
@@ -14,8 +14,8 @@ extension UIDevice {
     }
 
     var feedbackType: FeedbackType {
-        if let fsl = UIDevice.current.value(forKey: "_feedbackSupportLevel") as? Int, let feedbackSupportLevel = Int(fsl) {
-            return FeedbackType(rawValue: feedbackSupportLevel) ?? .base
+        if let fsl = UIDevice.current.value(forKey: "_feedbackSupportLevel") as? Int, let feedbackSupportLevel = FeedbackType(rawValue: Int(fsl)) {
+            return feedbackSupportLevel
         }
         return .base
     }

--- a/Utils/Utils/VibrationFeedbackManager/UIDevice+hasHapticFeedback.swift
+++ b/Utils/Utils/VibrationFeedbackManager/UIDevice+hasHapticFeedback.swift
@@ -1,0 +1,17 @@
+//
+//  UIDevice+hasHapticFeedback.swift
+//  Utils
+//
+//  Created by Павел Маринченко on 9/10/18.
+//  Copyright © 2018 Surf. All rights reserved.
+//
+
+import Device_swift
+
+public extension UIDevice {
+    // haptic feedback support guarantees that device supports taptic engine too.
+    var hasHapticFeedback: Bool {
+        let device = UIDevice.current.deviceType
+        return device == .iPhone7 || device == .iPhone7Plus || device == .iPhone8 || device == .iPhone8Plus || device == .iPhoneX
+    }
+}

--- a/Utils/Utils/VibrationFeedbackManager/UIDevice+hasHapticFeedback.swift
+++ b/Utils/Utils/VibrationFeedbackManager/UIDevice+hasHapticFeedback.swift
@@ -2,13 +2,13 @@
 //  UIDevice+hasHapticFeedback.swift
 //  Utils
 //
-//  Created by Павел Маринченко on 9/10/18.
+//  Created by Pavel Marinchenko on 9/10/18.
 //  Copyright © 2018 Surf. All rights reserved.
 //
 
 import Device_swift
 
-public extension UIDevice {
+extension UIDevice {
     // haptic feedback support guarantees that device supports taptic engine too.
     var hasHapticFeedback: Bool {
         let device = UIDevice.current.deviceType

--- a/Utils/Utils/VibrationFeedbackManager/UIDevice+hasHapticFeedback.swift
+++ b/Utils/Utils/VibrationFeedbackManager/UIDevice+hasHapticFeedback.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 Surf. All rights reserved.
 //
 
-import Device_swift
-
 extension UIDevice {
     // haptic feedback support guarantees that device supports taptic engine too.
     var hasHapticFeedback: Bool {

--- a/Utils/Utils/VibrationFeedbackManager/UIDevice+hasHapticFeedback.swift
+++ b/Utils/Utils/VibrationFeedbackManager/UIDevice+hasHapticFeedback.swift
@@ -11,7 +11,6 @@ import Device_swift
 extension UIDevice {
     // haptic feedback support guarantees that device supports taptic engine too.
     var hasHapticFeedback: Bool {
-        let device = UIDevice.current.deviceType
-        return device == .iPhone7 || device == .iPhone7Plus || device == .iPhone8 || device == .iPhone8Plus || device == .iPhoneX
+        return feedbackType == .haptic
     }
 }

--- a/Utils/Utils/VibrationFeedbackManager/UIDevice+hasTapticEngine.swift
+++ b/Utils/Utils/VibrationFeedbackManager/UIDevice+hasTapticEngine.swift
@@ -1,0 +1,16 @@
+//
+//  UIDevice+hasTapticEngine.swift
+//  Utils
+//
+//  Created by Павел Маринченко on 9/10/18.
+//  Copyright © 2018 Surf. All rights reserved.
+//
+
+import Device_swift
+
+public extension UIDevice {
+    var hasTapticEngine: Bool {
+        let device = UIDevice.current.deviceType
+        return device == .iPhone6S || device == .iPhone6SPlus || hasHapticFeedback
+    }
+}

--- a/Utils/Utils/VibrationFeedbackManager/UIDevice+hasTapticEngine.swift
+++ b/Utils/Utils/VibrationFeedbackManager/UIDevice+hasTapticEngine.swift
@@ -10,7 +10,6 @@ import Device_swift
 
 extension UIDevice {
     var hasTapticEngine: Bool {
-        let device = UIDevice.current.deviceType
-        return device == .iPhone6S || device == .iPhone6SPlus || hasHapticFeedback
+        return feedbackType == .taptic || hasHapticFeedback
     }
 }

--- a/Utils/Utils/VibrationFeedbackManager/UIDevice+hasTapticEngine.swift
+++ b/Utils/Utils/VibrationFeedbackManager/UIDevice+hasTapticEngine.swift
@@ -2,13 +2,13 @@
 //  UIDevice+hasTapticEngine.swift
 //  Utils
 //
-//  Created by Павел Маринченко on 9/10/18.
+//  Created by Pavel Marinchenko on 9/10/18.
 //  Copyright © 2018 Surf. All rights reserved.
 //
 
 import Device_swift
 
-public extension UIDevice {
+extension UIDevice {
     var hasTapticEngine: Bool {
         let device = UIDevice.current.deviceType
         return device == .iPhone6S || device == .iPhone6SPlus || hasHapticFeedback

--- a/Utils/Utils/VibrationFeedbackManager/UIDevice+hasTapticEngine.swift
+++ b/Utils/Utils/VibrationFeedbackManager/UIDevice+hasTapticEngine.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 Surf. All rights reserved.
 //
 
-import Device_swift
-
 extension UIDevice {
     var hasTapticEngine: Bool {
         return feedbackType == .taptic || hasHapticFeedback

--- a/Utils/Utils/VibrationFeedbackManager/VibrationFeedbackManager.swift
+++ b/Utils/Utils/VibrationFeedbackManager/VibrationFeedbackManager.swift
@@ -1,0 +1,159 @@
+//
+//  VibrationFeedbackManager.swift
+//  Utils
+//
+//  Created by Pavel Marinchenko on 9/10/18.
+//  Copyright © 2018 Surf. All rights reserved.
+//
+
+import AudioToolbox
+
+/**
+ *
+ * Util for managing user feedback actions.
+ *
+ * Util has some methods for playing vibrations. You can play feedback by event type.
+ * While you call feedback action the class autodetects user device type and plays correct vibrations.
+ *
+ * By default apple mobile devices has a few different vibration feedback systems.
+ * - Default vibrations available for all apple devices.
+ * - Taptic Engine 1.0 available for iPhone 6/6s and above.
+ * - Haptic Feedback (or taptic engine 2.0) available for iPhone 7/7s and above.
+ *
+ */
+public final class VibrationFeedbackManager {
+
+    // MARK: - Enums
+
+    public enum VibrationFeedbackEventType {
+        case tap
+        case error
+        case cancelled
+    }
+
+    /// supports by anything devices
+    fileprivate enum DefaultVibrationType {
+        case standard
+        case alert
+    }
+
+    /// supports by iphone 6s and above (taptic engine)
+    fileprivate enum TapticEngineVibrationType {
+        case peek
+        case pop
+        case cancelled
+        case tryagain
+        case failed
+    }
+
+    /// supports by iphone 7/7s and above (haptic feedback)
+    fileprivate enum HapticFeedbackVibrationType {
+        case success
+        case warning
+        case error
+
+        case light
+        case medium
+        case heavy
+
+        case selection
+    }
+
+    // MARK: - Internal Methods
+
+    public static func playVibrationFeedbackBy(event: VibrationFeedbackEventType) {
+        switch event {
+        case .tap:
+            if UIDevice.current.hasHapticFeedback {
+                playHapticFeedbackBy(type: .medium)
+            } else if UIDevice.current.hasTapticEngine {
+                playTapticFeedbackBy(type: .peek)
+            }
+        case .error:
+            if UIDevice.current.hasHapticFeedback {
+                playHapticFeedbackBy(type: .error)
+            } else if UIDevice.current.hasTapticEngine {
+                playTapticFeedbackBy(type: .cancelled)
+            } else {
+                playDefaultFeedbackBy(type: .standard)
+            }
+        case .cancelled:
+            if UIDevice.current.hasHapticFeedback {
+                playHapticFeedbackBy(type: .warning)
+            } else if UIDevice.current.hasTapticEngine {
+                playTapticFeedbackBy(type: .cancelled)
+            }
+        }
+    }
+
+}
+
+// MARK: - Private methods
+
+private extension VibrationFeedbackManager {
+    static func playDefaultFeedbackBy(type: DefaultVibrationType) {
+        switch type {
+        case .standard:
+            let standard = SystemSoundID(kSystemSoundID_Vibrate)
+            AudioServicesPlaySystemSound(standard)
+        case .alert:
+            let alert = SystemSoundID(1011)
+            AudioServicesPlaySystemSound(alert)
+        }
+    }
+
+    static func playTapticFeedbackBy(type: TapticEngineVibrationType) {
+        switch type {
+        case .peek:
+            let peek = SystemSoundID(1519)
+            AudioServicesPlaySystemSound(peek)
+        case .pop:
+            let pop = SystemSoundID(1520)
+            AudioServicesPlaySystemSound(pop)
+        case .cancelled:
+            let cancelled = SystemSoundID(1521)
+            AudioServicesPlaySystemSound(cancelled)
+        case .tryagain:
+            let tryagain = SystemSoundID(1102)
+            AudioServicesPlaySystemSound(tryagain)
+        case .failed:
+            let failed = SystemSoundID(1107)
+            AudioServicesPlaySystemSound(failed)
+        }
+    }
+
+    static func playHapticFeedbackBy(type: HapticFeedbackVibrationType) {
+        switch type {
+        case .success:
+            let hapticNotification = UINotificationFeedbackGenerator()
+            hapticNotification.prepare()
+            hapticNotification.notificationOccurred(.success)
+        case .warning:
+            let hapticNotification = UINotificationFeedbackGenerator()
+            hapticNotification.prepare()
+            hapticNotification.notificationOccurred(.warning)
+        case .error:
+            let hapticNotification = UINotificationFeedbackGenerator()
+            hapticNotification.prepare()
+            hapticNotification.notificationOccurred(.error)
+
+        case .light:
+            let hapticLightFeedback = UIImpactFeedbackGenerator(style: .light)
+            hapticLightFeedback.prepare()
+            hapticLightFeedback.impactOccurred()
+        case .medium:
+            let hapticLightFeedback = UIImpactFeedbackGenerator(style: .medium)
+            hapticLightFeedback.prepare()
+            hapticLightFeedback.impactOccurred()
+        case .heavy:
+            let hapticLightFeedback = UIImpactFeedbackGenerator(style: .heavy)
+            hapticLightFeedback.prepare()
+            hapticLightFeedback.impactOccurred()
+
+        case .selection:
+            let selectionFeedback = UISelectionFeedbackGenerator()
+            selectionFeedback.prepare()
+            selectionFeedback.selectionChanged()
+        }
+    }
+}

--- a/Utils/Utils/VibrationFeedbackManager/VibrationFeedbackManager.swift
+++ b/Utils/Utils/VibrationFeedbackManager/VibrationFeedbackManager.swift
@@ -17,11 +17,21 @@ import AudioToolbox
  *
  * By default apple mobile devices has a few different vibration feedback systems.
  * - Default vibrations available for all apple devices.
- * - Taptic Engine 1.0 available for iPhone 6/6s and above.
- * - Haptic Feedback (or taptic engine 2.0) available for iPhone 7/7s and above.
+ * - Taptic Engine 1.0 available for iPhone 6s and above.
+ * - Haptic Feedback (or taptic engine 2.0) available for iPhone 7 and above.
  *
  */
 public final class VibrationFeedbackManager {
+
+    // MARK: - Constants
+
+    private struct SoundID {
+      static let peek = 1519
+      static let pop = 1520
+      static let cancelled = 1521
+      static let tryagain = 1102
+      static let failed = 1107
+    }
 
     // MARK: - Enums
 
@@ -105,19 +115,19 @@ private extension VibrationFeedbackManager {
     static func playTapticFeedbackBy(type: TapticEngineVibrationType) {
         switch type {
         case .peek:
-            let peek = SystemSoundID(1519)
+            let peek = SystemSoundID(SoundID.peek)
             AudioServicesPlaySystemSound(peek)
         case .pop:
-            let pop = SystemSoundID(1520)
+            let pop = SystemSoundID(SoundID.pop)
             AudioServicesPlaySystemSound(pop)
         case .cancelled:
-            let cancelled = SystemSoundID(1521)
+            let cancelled = SystemSoundID(SoundID.cancelled)
             AudioServicesPlaySystemSound(cancelled)
         case .tryagain:
-            let tryagain = SystemSoundID(1102)
+            let tryagain = SystemSoundID(SoundID.tryagain)
             AudioServicesPlaySystemSound(tryagain)
         case .failed:
-            let failed = SystemSoundID(1107)
+            let failed = SystemSoundID(SoundID.failed)
             AudioServicesPlaySystemSound(failed)
         }
     }

--- a/Utils/Utils/VibrationFeedbackManager/VibrationFeedbackManager.swift
+++ b/Utils/Utils/VibrationFeedbackManager/VibrationFeedbackManager.swift
@@ -25,6 +25,7 @@ public final class VibrationFeedbackManager {
 
     // MARK: - Constants
 
+    // ids -> http://iphonedevwiki.net/index.php/AudioServices
     private struct SoundID {
         static let peek = 1519
         static let pop = 1520

--- a/Utils/Utils/VibrationFeedbackManager/VibrationFeedbackManager.swift
+++ b/Utils/Utils/VibrationFeedbackManager/VibrationFeedbackManager.swift
@@ -18,7 +18,7 @@ import AudioToolbox
  * By default apple mobile devices has a few different vibration feedback systems.
  * - Default vibrations available for all apple devices.
  * - Taptic Engine 1.0 available for iPhone 6s and above.
- * - Haptic Feedback (or taptic engine 2.0) available for iPhone 7 and above.
+ * - Haptic Feedback (taptic engine 2.0) available for iPhone 7 and above.
  *
  */
 public final class VibrationFeedbackManager {
@@ -26,38 +26,60 @@ public final class VibrationFeedbackManager {
     // MARK: - Constants
 
     private struct SoundID {
-      static let peek = 1519
-      static let pop = 1520
-      static let cancelled = 1521
-      static let tryagain = 1102
-      static let failed = 1107
+        static let peek = 1519
+        static let pop = 1520
+        static let cancelled = 1521
+        static let tryagain = 1102
+        static let failed = 1107
+
+        static let standard = kSystemSoundID_Vibrate
+        static let alert = 1011
     }
 
     // MARK: - Enums
 
-    public enum VibrationFeedbackEventType {
+    public enum Event {
         case tap
         case error
         case cancelled
     }
 
     /// supports by anything devices
-    fileprivate enum DefaultVibrationType {
+    private enum DefaultVibrationType {
         case standard
         case alert
+
+        /// returns relevant instance of sound id
+        var systemSound: SystemSoundID {
+            switch self {
+            case .standard: return SystemSoundID(SoundID.standard)
+            case .alert: return SystemSoundID(SoundID.alert)
+            }
+        }
     }
 
     /// supports by iphone 6s and above (taptic engine)
-    fileprivate enum TapticEngineVibrationType {
+    private enum TapticEngineVibrationType {
         case peek
         case pop
         case cancelled
         case tryagain
         case failed
+
+        /// returns relevant instance of sound id
+        var systemSound: SystemSoundID {
+            switch self {
+            case .peek: return SystemSoundID(SoundID.peek)
+            case .pop: return SystemSoundID(SoundID.pop)
+            case .cancelled: return SystemSoundID(SoundID.cancelled)
+            case .tryagain: return SystemSoundID(SoundID.tryagain)
+            case .failed: return SystemSoundID(SoundID.failed)
+            }
+        }
     }
 
     /// supports by iphone 7/7s and above (haptic feedback)
-    fileprivate enum HapticFeedbackVibrationType {
+    private enum HapticFeedbackVibrationType {
         case success
         case warning
         case error
@@ -71,7 +93,7 @@ public final class VibrationFeedbackManager {
 
     // MARK: - Internal Methods
 
-    public static func playVibrationFeedbackBy(event: VibrationFeedbackEventType) {
+    public static func playVibrationFeedbackBy(event: Event) {
         switch event {
         case .tap:
             if UIDevice.current.hasHapticFeedback {
@@ -101,38 +123,15 @@ public final class VibrationFeedbackManager {
 // MARK: - Private methods
 
 private extension VibrationFeedbackManager {
-    static func playDefaultFeedbackBy(type: DefaultVibrationType) {
-        switch type {
-        case .standard:
-            let standard = SystemSoundID(kSystemSoundID_Vibrate)
-            AudioServicesPlaySystemSound(standard)
-        case .alert:
-            let alert = SystemSoundID(1011)
-            AudioServicesPlaySystemSound(alert)
-        }
+    private static func playDefaultFeedbackBy(type: DefaultVibrationType) {
+        AudioServicesPlaySystemSound(type.systemSound)
     }
 
-    static func playTapticFeedbackBy(type: TapticEngineVibrationType) {
-        switch type {
-        case .peek:
-            let peek = SystemSoundID(SoundID.peek)
-            AudioServicesPlaySystemSound(peek)
-        case .pop:
-            let pop = SystemSoundID(SoundID.pop)
-            AudioServicesPlaySystemSound(pop)
-        case .cancelled:
-            let cancelled = SystemSoundID(SoundID.cancelled)
-            AudioServicesPlaySystemSound(cancelled)
-        case .tryagain:
-            let tryagain = SystemSoundID(SoundID.tryagain)
-            AudioServicesPlaySystemSound(tryagain)
-        case .failed:
-            let failed = SystemSoundID(SoundID.failed)
-            AudioServicesPlaySystemSound(failed)
-        }
+    private static func playTapticFeedbackBy(type: TapticEngineVibrationType) {
+        AudioServicesPlaySystemSound(type.systemSound)
     }
 
-    static func playHapticFeedbackBy(type: HapticFeedbackVibrationType) {
+    private static func playHapticFeedbackBy(type: HapticFeedbackVibrationType) {
         switch type {
         case .success:
             let hapticNotification = UINotificationFeedbackGenerator()


### PR DESCRIPTION
Утилита позволяет проигрывать вибрацию на разные эвенты: тапы, ошибки и успех. Пользователь просто вызывает функцию playFeedbackBy(event: .tap), а утилита сама распознает какой тип вибрации поддерживается на устройства, так как офигенный haptic feedback идет только от семерок, а более менее нормальный taptic engine 1.0 – от 6s.

То есть это спасает еще от того, чтобы по тапу не воспроизводилась хардкорная анимация на лоу устройствах, а на каких-то iphone X – воспроизводилась.

В будущем, хочу класс-конфиг добавить, чтобы параметры конфигурации можно было устанавливать. Плюс какой-нибудь еще кейс эксплуатации утилиты, помимо простого вызвова метода во всех местах, где это нужно.