### PR TITLE
#14 Исправление бага с lineSpacing

### DIFF
--- a/Surf-Utils.podspec
+++ b/Surf-Utils.podspec
@@ -1,11 +1,13 @@
 Pod::Spec.new do |s|
 
   s.name = "SurfUtils"
-  s.version = "2.0.7"
+  s.version = "3.0.0"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:
     - Extension for easy use NSAttributedString
+    - Method for detection JailBreak
+    - Manager for easily use vibration features
                    DESC
 
   s.homepage  = "https://github.com/surfstudio/ios-utils"

--- a/Utils/Utils/String/String+Attributes.swift
+++ b/Utils/Utils/String/String+Attributes.swift
@@ -11,8 +11,8 @@ import UIKit
 
 /// Attributes for string.
 public enum StringAttribute {
-    /// Text line height
-    case lineHeight(CGFloat)
+    /// Text line spacing
+    case lineSpacing(CGFloat)
     /// Letter spacing
     case kern(CGFloat)
     /// Text font
@@ -22,9 +22,15 @@ public enum StringAttribute {
     /// Text aligment
     case aligment(NSTextAlignment)
 
+    /// Figma friendly case means that lineSpacing = lineHeight - font.lineHeight
+    /// This case provide possibility to set both `font` and `lineSpacing`
+    /// First parameter is Font and second parameter is lineHeight property from Figma
+    /// For more details see [#14](https://github.com/surfstudio/iOS-Utils/issues/14)
+    case lineHeight(UIFont, CGFloat)
+
     var attributeKey: NSAttributedStringKey {
         switch self {
-        case .lineHeight, .aligment:
+        case .lineSpacing, .aligment, .lineHeight:
             return NSAttributedStringKey.paragraphStyle
         case .kern:
             return NSAttributedStringKey.kern
@@ -37,7 +43,7 @@ public enum StringAttribute {
 
     fileprivate var value: Any {
         switch self {
-        case .lineHeight(let value):
+        case .lineSpacing(let value):
             return value
         case .kern(let value):
             return value
@@ -47,6 +53,8 @@ public enum StringAttribute {
             return value
         case .aligment(let value):
             return value
+        case .lineHeight(let font, let lineHeight):
+            return lineHeight - font.lineHeight
         }
     }
 }
@@ -57,9 +65,12 @@ public extension String {
     func with(attributes: [StringAttribute]) -> NSAttributedString {
         var resultAttributes = [NSAttributedStringKey: Any]()
         let paragraph = NSMutableParagraphStyle()
-        for attribute in attributes {
+        for attribute in attributes.normalizedAttributes() {
             switch attribute {
-            case .lineHeight(let value):
+            case .lineHeight(let font, let height):
+                paragraph.lineSpacing = height - font.lineHeight
+                resultAttributes[attribute.attributeKey] = paragraph
+            case .lineSpacing(let value):
                 paragraph.lineSpacing = value
                 resultAttributes[attribute.attributeKey] = paragraph
             case .aligment(let value):
@@ -70,5 +81,21 @@ public extension String {
             }
         }
         return NSAttributedString(string: self, attributes: resultAttributes)
+    }
+}
+
+private extension Array where Element == StringAttribute {
+    func normalizedAttributes() -> [StringAttribute] {
+        var result = [StringAttribute](self)
+
+        self.forEach { item in
+            switch item {
+            case .lineHeight(let font, _):
+                result.append(.font(font))
+            default: break
+            }
+        }
+
+        return result
     }
 }

--- a/Utils/Utils/String/String+Attributes.swift
+++ b/Utils/Utils/String/String+Attributes.swift
@@ -26,7 +26,7 @@ public enum StringAttribute {
     /// This case provide possibility to set both `font` and `lineSpacing`
     /// First parameter is Font and second parameter is lineHeight property from Figma
     /// For more details see [#14](https://github.com/surfstudio/iOS-Utils/issues/14)
-    case lineHeight(UIFont, CGFloat)
+    case lineHeight(CGFloat, UIFont)
 
     var attributeKey: NSAttributedStringKey {
         switch self {
@@ -53,7 +53,7 @@ public enum StringAttribute {
             return value
         case .aligment(let value):
             return value
-        case .lineHeight(let font, let lineHeight):
+        case .lineHeight(let lineHeight, let font):
             return lineHeight - font.lineHeight
         }
     }
@@ -67,8 +67,8 @@ public extension String {
         let paragraph = NSMutableParagraphStyle()
         for attribute in attributes.normalizedAttributes() {
             switch attribute {
-            case .lineHeight(let font, let height):
-                paragraph.lineSpacing = height - font.lineHeight
+            case .lineHeight(let lineHeight, let font):
+                paragraph.lineSpacing = lineHeight - font.lineHeight
                 resultAttributes[attribute.attributeKey] = paragraph
             case .lineSpacing(let value):
                 paragraph.lineSpacing = value
@@ -90,7 +90,7 @@ private extension Array where Element == StringAttribute {
 
         self.forEach { item in
             switch item {
-            case .lineHeight(let font, _):
+            case .lineHeight(_, let font):
                 result.append(.font(font))
             default: break
             }

--- a/Utils/Utils/String/String+Attributes.swift
+++ b/Utils/Utils/String/String+Attributes.swift
@@ -26,7 +26,7 @@ public enum StringAttribute {
     /// This case provide possibility to set both `font` and `lineSpacing`
     /// First parameter is Font and second parameter is lineHeight property from Figma
     /// For more details see [#14](https://github.com/surfstudio/iOS-Utils/issues/14)
-    case lineHeight(CGFloat, UIFont)
+    case lineHeight(CGFloat, font: UIFont)
 
     var attributeKey: NSAttributedStringKey {
         switch self {


### PR DESCRIPTION
#14 
Переименовал прошлый `.lineHeight` в `.lineSpacing`. 
Добавил `.lineHeight`, который в качестве параметров имеет `UIFont` - шрифт и `CGFloat` - значение `lineHeight` из Figma. 
Используя `.lineHeight` не надо дополнительно устанавливать `.font`, так как при использовании `.lineHeight` устанавливаются и `Font` и `LineSpacing`