### PR TITLE
Keyboard presentable

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ scrollManager = ItemsScrollManager(cellWidth: 200,
                                    cellOffset: 10,
                                    insets: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
 
+// При этом необходимо помнить о том, что отступы для секции UICollectionView необходимо установить самому, к примеру:
+let flowLayout = UICollectionViewFlowLayout()
+flowLayout.scrollDirection = .horizontal
+flowLayout.sectionInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
+collectionView.setCollectionViewLayout(flowLayout, animated: false)
+
 // После чего необходимо добавить вызовы следующих методов в методы UIScrollViewDelegate
 extension ViewController: UIScrollViewDelegate {
 
@@ -158,15 +164,13 @@ extension ViewController: UIScrollViewDelegate {
 
 Пример:
 ```Swift
-/// Для подписки на нотификации появления/сокрытия клавиатуры необходимо вызывать:
+// Для подписки на нотификации появления/сокрытия клавиатуры необходимо вызывать:
 subscribeOnKeyboardNotifications()
 
-/// Для отписывания от нотификаций появления/сокрытия клавиатуры необходимо вызывать:
+// Для отписывания от нотификаций появления/сокрытия клавиатуры необходимо вызывать:
 unsubscribeFromKeyboardNotifications()
 
-/// В результате появления/сокрытия клавиатуры будут вызываться следующие методы, в которые приходят такие параметры, как высота клавиатуры и время анимации
-
-// MARK: - KeyboardPresentable
+// В результате появления/сокрытия клавиатуры будут вызываться следующие методы, в которые приходят такие параметры, как высота клавиатуры и время анимации
 
 extension ViewController: KeyboardPresentable {
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pod 'SurfUtils/$UTIL_NAME$', :git => "https://github.com/surfstudio/iOS-Utils.gi
 - [AdvancedNavigationStackManagement](#advancednavigationstackmanagement) - расширенная версия методов push/pop у UINavigationController
 - [WordDeclinationSelector](#worddeclinationselector) - позволяет получить нужное склонение слова
 - [ItemsScrollManager](#itemsscrollmanager) - менеджер для поэлементного скролла карусели
+- [KeyboardPresentable](#keyboardpresentable) - протокол для упрощения работы с клавиатурой и сокращения количества одинакового кода
 
 
 ## Утилиты
@@ -145,6 +146,36 @@ extension ViewController: UIScrollViewDelegate {
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         scrollManager?.setBeginDraggingOffset(scrollView.contentOffset.x)
+    }
+
+}
+```
+
+### KeyboardPresentable
+
+Протокол, цель которого - сократить кол-во одинаковых действий при работе с клавиатурой. В ходе данных работ выполняется, как правило, ряд действий, код которых идентичен в большинстве случаев - подписка на нотификации, отписывание от них, извлечение параметров из нотификации, таких как высота клавиатуры или время анимации. Протокол KeyboardPresentable написан с целью сокращения количества одинакового кода.
+Для его использования достаточно создать extension на необходимый UIViewController, в котором переопределить при необходимости два метода. Для подписки же или отписывания от нотификации - нужно вызывать методы данного протокола, реализация которых уже заложена внутри.
+
+Пример:
+```Swift
+/// Для подписки на нотификации появления/сокрытия клавиатуры необходимо вызывать:
+subscribeOnKeyboardNotifications()
+
+/// Для отписывания от нотификаций появления/сокрытия клавиатуры необходимо вызывать:
+unsubscribeFromKeyboardNotifications()
+
+/// В результате появления/сокрытия клавиатуры будут вызываться следующие методы, в которые приходят такие параметры, как высота клавиатуры и время анимации
+
+// MARK: - KeyboardPresentable
+
+extension ViewController: KeyboardPresentable {
+
+    func keyboardWillBeShown(keyboardHeight: CGFloat, duration: TimeInterval) {
+        // do something useful
+    }
+
+    func keyboardWillBeHidden(duration: TimeInterval) {
+        // do something useful
     }
 
 }

--- a/SurfUtils.podspec
+++ b/SurfUtils.podspec
@@ -68,4 +68,9 @@ Pod::Spec.new do |s|
     sp.framework = 'UIKit'
   end
 
+  s.subspec 'KeyboardPresentable' do |sp|
+    sp.source_files = 'Utils/Utils/KeyboardPresentable/KeyboardPresentable.swift', 'Utils/Utils/KeyboardPresentable/KeyboardNotificationsObserver.swift'
+    sp.framework = 'UIKit'
+  end
+
 end

--- a/Utils/Utils.xcodeproj/project.pbxproj
+++ b/Utils/Utils.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		80437D26214045EF0095A8D0 /* JailbreakDetect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80437D25214045EF0095A8D0 /* JailbreakDetect.swift */; };
 		902C67EC21E4D20B007B13CC /* ItemsScrollManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902C67EB21E4D20B007B13CC /* ItemsScrollManager.swift */; };
 		902CA34121E7331E00396923 /* UIView+BlurBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902CA34021E7331E00396923 /* UIView+BlurBuilder.swift */; };
+		90718AEF21EA36F300C81002 /* KeyboardPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90718AEE21EA36F300C81002 /* KeyboardPresentable.swift */; };
+		90718AF121EA370000C81002 /* KeyboardNotificationsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90718AF021EA370000C81002 /* KeyboardNotificationsObserver.swift */; };
 		907F0FE321DCD20C001CCB07 /* UINavigationController+AdvancedNavigationStackManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F0FE221DCD20C001CCB07 /* UINavigationController+AdvancedNavigationStackManagement.swift */; };
 		907F0FE621DCD3A0001CCB07 /* SettingsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F0FE521DCD3A0001CCB07 /* SettingsRouter.swift */; };
 		907F0FEC21DCD7E1001CCB07 /* RouteMeasurer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907F0FEB21DCD7E1001CCB07 /* RouteMeasurer.swift */; };
@@ -47,6 +49,8 @@
 		80437D25214045EF0095A8D0 /* JailbreakDetect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JailbreakDetect.swift; sourceTree = "<group>"; };
 		902C67EB21E4D20B007B13CC /* ItemsScrollManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemsScrollManager.swift; sourceTree = "<group>"; };
 		902CA34021E7331E00396923 /* UIView+BlurBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+BlurBuilder.swift"; sourceTree = "<group>"; };
+		90718AEE21EA36F300C81002 /* KeyboardPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPresentable.swift; sourceTree = "<group>"; };
+		90718AF021EA370000C81002 /* KeyboardNotificationsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardNotificationsObserver.swift; sourceTree = "<group>"; };
 		907F0FE221DCD20C001CCB07 /* UINavigationController+AdvancedNavigationStackManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+AdvancedNavigationStackManagement.swift"; sourceTree = "<group>"; };
 		907F0FE521DCD3A0001CCB07 /* SettingsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRouter.swift; sourceTree = "<group>"; };
 		907F0FEB21DCD7E1001CCB07 /* RouteMeasurer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMeasurer.swift; sourceTree = "<group>"; };
@@ -110,6 +114,7 @@
 				18F2361221D214CC00169AC9 /* Dictionary */,
 				902C67EA21E4D1EF007B13CC /* ItemsScrollManager */,
 				80437D24214045B30095A8D0 /* JailbreakDetect */,
+				90718AED21EA36CA00C81002 /* KeyboardPresentable */,
 				907F0FEA21DCD7C6001CCB07 /* RouteMeasurer */,
 				907F0FE421DCD375001CCB07 /* SettingsRouter */,
 				4F3ED9FA211C27E80030DD45 /* String */,
@@ -163,6 +168,15 @@
 				902CA34021E7331E00396923 /* UIView+BlurBuilder.swift */,
 			);
 			path = UIView;
+			sourceTree = "<group>";
+		};
+		90718AED21EA36CA00C81002 /* KeyboardPresentable */ = {
+			isa = PBXGroup;
+			children = (
+				90718AEE21EA36F300C81002 /* KeyboardPresentable.swift */,
+				90718AF021EA370000C81002 /* KeyboardNotificationsObserver.swift */,
+			);
+			path = KeyboardPresentable;
 			sourceTree = "<group>";
 		};
 		907F0FE121DCD1DB001CCB07 /* UINavigationController */ = {
@@ -325,7 +339,9 @@
 				907F0FE621DCD3A0001CCB07 /* SettingsRouter.swift in Sources */,
 				E9B0630C214692C30080C391 /* UIDevice+hasTapticEngine.swift in Sources */,
 				80437D26214045EF0095A8D0 /* JailbreakDetect.swift in Sources */,
+				90718AEF21EA36F300C81002 /* KeyboardPresentable.swift in Sources */,
 				E9B0630E214693160080C391 /* UIDevice+hasHapticFeedback.swift in Sources */,
+				90718AF121EA370000C81002 /* KeyboardNotificationsObserver.swift in Sources */,
 				4F3ED9FC211C27FD0030DD45 /* String+Attributes.swift in Sources */,
 				902CA34121E7331E00396923 /* UIView+BlurBuilder.swift in Sources */,
 				907F0FEF21DCDB43001CCB07 /* WordDeclinationSelector.swift in Sources */,

--- a/Utils/Utils/KeyboardPresentable/KeyboardNotificationsObserver.swift
+++ b/Utils/Utils/KeyboardPresentable/KeyboardNotificationsObserver.swift
@@ -1,0 +1,60 @@
+//
+//  KeyboardNotificationsObserver.swift
+//  Utils
+//
+//  Created by Александр Чаусов on 12/01/2019.
+//  Copyright © 2019 Surf. All rights reserved.
+//
+
+import UIKit
+
+fileprivate enum Constants {
+    static let animationDuration: TimeInterval = 0.25
+}
+
+/// An instance of this class is responsible for handling notifications when the keyboard appears and disappears.
+/// Its necessity is caused by the fact that in the protocol extension you cannot declare methods with the @objc identifier.
+final class KeyboardNotificationsObserver {
+
+    // MARK: - Private Properties
+
+    private weak var view: KeyboardPresentable?
+
+    // MARK: - Initialization
+
+    init(view: KeyboardPresentable) {
+        self.view = view
+    }
+
+    // MARK: - Internal Methods
+
+    @objc
+    func keyboardWillBeShown(notification: Notification) {
+        guard let keyboardFrame: NSValue = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSValue else {
+            return
+        }
+        let keyboardHeight = keyboardFrame.cgRectValue.height
+        let duration = animationDuration(from: notification)
+        view?.keyboardWillBeShown(keyboardHeight: keyboardHeight, duration: duration)
+    }
+
+    @objc
+    func keyboardWillBeHidden(notification: Notification) {
+        let duration = animationDuration(from: notification)
+        view?.keyboardWillBeHidden(duration: duration)
+    }
+
+}
+
+// MARK: - Private Methods
+
+private extension KeyboardNotificationsObserver {
+
+    func animationDuration(from notification: Notification) -> TimeInterval {
+        guard let duration = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? NSNumber else {
+            return Constants.animationDuration
+        }
+        return TimeInterval(truncating: duration)
+    }
+
+}

--- a/Utils/Utils/KeyboardPresentable/KeyboardPresentable.swift
+++ b/Utils/Utils/KeyboardPresentable/KeyboardPresentable.swift
@@ -1,0 +1,73 @@
+//
+//  KeyboardPresentable.swift
+//  Utils
+//
+//  Created by Александр Чаусов on 12/01/2019.
+//  Copyright © 2019 Surf. All rights reserved.
+//
+
+import UIKit
+
+fileprivate enum AssociatedKeys {
+    static var observer: UInt8 = 0
+}
+
+/// This protocol carries out all the necessary actions for subscribing / unsubscribing from keyboard notifications, as well as calculating the keyboard height and animation time
+public protocol KeyboardPresentable: class {
+
+    /// Method for subscribing on keyboard notifications
+    func subscribeOnKeyboardNotifications()
+
+    /// Method for unsubscribing from keyboard notifications
+    func unsubscribeFromKeyboardNotifications()
+
+    /// This method is called when the keyboard appears on the device screen
+    func keyboardWillBeShown(keyboardHeight: CGFloat, duration: TimeInterval)
+
+    /// This method is called when the keyboard disappears from the device screen
+    func keyboardWillBeHidden(duration: TimeInterval)
+
+}
+
+extension KeyboardPresentable where Self: UIViewController {
+
+    // MARK: - Private Properties
+
+    private var observer: KeyboardNotificationsObserver? {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.observer) as? KeyboardNotificationsObserver
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.observer, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    // MARK: - Public Methods
+
+    func subscribeOnKeyboardNotifications() {
+        let notificationsObserver = KeyboardNotificationsObserver(view: self)
+        observer = notificationsObserver
+
+        let center = NotificationCenter.default
+        center.addObserver(notificationsObserver,
+                           selector: #selector(KeyboardNotificationsObserver.keyboardWillBeShown(notification:)),
+                           name: NSNotification.Name.UIKeyboardWillShow,
+                           object: nil)
+        center.addObserver(notificationsObserver,
+                           selector: #selector(KeyboardNotificationsObserver.keyboardWillBeHidden(notification:)),
+                           name: NSNotification.Name.UIKeyboardWillShow,
+                           object: nil)
+    }
+
+    func unsubscribeFromKeyboardNotifications() {
+        guard let observer = observer else {
+            return
+        }
+        NotificationCenter.default.removeObserver(observer)
+    }
+
+    func keyboardWillBeShown(keyboardHeight: CGFloat, duration: TimeInterval) {}
+
+    func keyboardWillBeHidden(duration: TimeInterval) {}
+
+}


### PR DESCRIPTION
Давно эту идею носил, вот наконец-то родил.
Мысль такая - полазил по разным проектам, посмотрел, сравнил с тем что видел - везде одно и то же(
Проблема следующая - при работе с клавой куча бойлерплейта: надо подписаться на нотификации, отписаться от них, достать из нотификации высоту, время анимации и т.д. И везде этот код копипастится по факту.

Соответственно, в данном ПР - попытка вынести весь бойлерплейт в протокол и уже его использовать.
Стратегия такая - в протоколе четыре метода. Подписаться/отписаться - имеют дефолтную реализацию, надо вызывать их. И еще два метода - на появление/сокрытие, их уже можно переопределять и писать что душе угодно, при этом в них уже готовыми приходят высота клавиатуры и время анимации.

Вот дальше начинаются вопросы, правильно или неправильно я сделал: 

- если высоту извлечь не удалось, то и метод на появление дергаться не будет. При этом на время анимации не такие жесткие условия - если его из нотификации не удалось извлечь - будет возвращено дефолтное значение из константы

- в протоколе нельзя определять методы с идентификатором @objc, так что пришлось на нотификации подписывать не ViewController, а другой объект. Соответственно там вычисляемое property, насчет его реализации тоже куча вопросов - правильно я все сделал, нет... кто более опытный, подскажите) я первый раз таким занимаюсь

- @ismetanin посмотрел на ваш проект, не буду называть какой =), там помимо высоты вы еще параметры достаете. Напиши тогда, что еще вам нужно, ну или в принципе кто подскажет, что еще обычно пригождается. Я на своей памяти кроме этих двух вроде ничего больше не юзал. Может еще что-нибудь добавим

- ну и насчет AssociatedKeys, это опять же к теме с objc_getAssociatedObject/objc_setAssociatedObject, правильно или нет я с ним работаю?

Ну и чуть-чуть readme по ItemsScrollManager дополнил, а то @JohnReeze не справился с интегрированием в проект без подсказки)

Тестовый проект, где это можно в деле посмотреть - https://cloud.mail.ru/public/KPT1/oXWeAA6xD