### PR TITLE
Skeleton view fixes

### DIFF
--- a/SurfUtils.podspec
+++ b/SurfUtils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "SurfUtils"
-  s.version = "8.0.0"
+  s.version = "8.0.1"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:

--- a/Utils/Utils/SkeletonView/SkeletonView.swift
+++ b/Utils/Utils/SkeletonView/SkeletonView.swift
@@ -88,7 +88,10 @@ open class SkeletonView: UIView {
         configureGradientLayer()
         updateColors()
         maskingViews = subviews
-        shimmerRatio = 1.0
+        (leftLocations, rightLocations) = configureGradientLocations(for: shimmerRatio)
+        if shimmering {
+            startAnimating()
+        }
     }
 
 }


### PR DESCRIPTION
Не уверен, что в ветку swift-5 сливать, но пока ее не смержили - направлю туда.

Здесь пару фиксов для скелетон-лоадеров.

- во-первых, если запустить анимацию до того, как скелетон лоадер отрисовался - то он не запустится, ибо создание layer происходит на метод draw(rect:). А это часто используемый кейс. Потому в конце этого метода проверяем, запустил ли пользователь анимацию, и если да - то перезапускаем

- во-вторых, ratio не работает( из-за того, что в том же методе он устанавливался в 1, чтобы отработали сеттеры, вот он и переопределялся. Потому заменил это на код из сеттера