### PR TITLE
Keyboard presentable additional methods

### DIFF
--- a/SurfUtils.podspec
+++ b/SurfUtils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "SurfUtils"
-  s.version = "8.0.0"
+  s.version = "8.1.0"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:

--- a/Utils/Utils/KeyboardPresentable/CommonKeyboardPresentable.swift
+++ b/Utils/Utils/KeyboardPresentable/CommonKeyboardPresentable.swift
@@ -22,6 +22,12 @@ public protocol CommonKeyboardPresentable: class {
     /// This method is called when the keyboard disappears from the device screen
     func keyboardWillBeHidden(duration: TimeInterval)
 
+    /// This method is called after the keyboard appears on the device screen. Optional Method
+    func keyboardWasShown(keyboardHeight: CGFloat, duration: TimeInterval)
+
+    /// This method is called after the keyboard disappears from the device screen. Optional Method
+    func keyboardWasHidden(duration: TimeInterval)
+
 }
 
 public extension CommonKeyboardPresentable where Self: KeyboardObservable {
@@ -37,6 +43,27 @@ public extension CommonKeyboardPresentable where Self: KeyboardObservable {
     func keyboardWillBeHidden(notification: Notification) {
         let duration = notification.keyboardInfo.animationDuration ?? Constants.animationDuration
         keyboardWillBeHidden(duration: duration)
+    }
+
+    func keyboardWasShown(notification: Notification) {
+        guard let keyboardHeight = notification.keyboardInfo.frameEnd?.height else {
+            return
+        }
+        let duration = notification.keyboardInfo.animationDuration ?? Constants.animationDuration
+        keyboardWasShown(keyboardHeight: keyboardHeight, duration: duration)
+    }
+
+    func keyboardWasHidden(notification: Notification) {
+        let duration = notification.keyboardInfo.animationDuration ?? Constants.animationDuration
+        keyboardWasHidden(duration: duration)
+    }
+
+    // MARK: - Optional Method
+
+    func keyboardWasShown(keyboardHeight: CGFloat, duration: TimeInterval) {
+    }
+
+    func keyboardWasHidden(duration: TimeInterval) {
     }
 
 }

--- a/Utils/Utils/KeyboardPresentable/FullKeyboardPresentable.swift
+++ b/Utils/Utils/KeyboardPresentable/FullKeyboardPresentable.swift
@@ -18,6 +18,12 @@ public protocol FullKeyboardPresentable: class {
     /// This method is called when the keyboard disappears from the device screen
     func keyboardWillBeHidden(keyboardInfo: Notification.KeyboardInfo)
 
+    /// This method is called after the keyboard appears on the device screen
+    func keyboardWasShown(keyboardInfo: Notification.KeyboardInfo)
+
+    /// This method is called after the keyboard disappears from the device screen
+    func keyboardWasHidden(keyboardInfo: Notification.KeyboardInfo)
+
 }
 
 public extension FullKeyboardPresentable where Self: KeyboardObservable {
@@ -28,6 +34,22 @@ public extension FullKeyboardPresentable where Self: KeyboardObservable {
 
     func keyboardWillBeHidden(notification: Notification) {
         keyboardWillBeHidden(keyboardInfo: notification.keyboardInfo)
+    }
+
+    func keyboardWasShown(notification: Notification) {
+        keyboardWasShown(keyboardInfo: notification.keyboardInfo)
+    }
+
+    func keyboardWasHidden(notification: Notification) {
+        keyboardWasHidden(keyboardInfo: notification.keyboardInfo)
+    }
+
+    // MARK: - Optional Method
+
+    func keyboardWasShown(keyboardInfo: Notification.KeyboardInfo) {
+    }
+
+    func keyboardWasHidden(keyboardInfo: Notification.KeyboardInfo) {
     }
 
 }

--- a/Utils/Utils/KeyboardPresentable/KeyboardNotificationsObserver.swift
+++ b/Utils/Utils/KeyboardPresentable/KeyboardNotificationsObserver.swift
@@ -41,6 +41,16 @@ final class KeyboardNotificationsObserver {
         view?.keyboardWillBeHidden(notification: notification)
     }
 
+    @objc
+    func keyboardWasShown(notification: Notification) {
+        view?.keyboardWasShown(notification: notification)
+    }
+
+    @objc
+    func keyboardWasHidden(notification: Notification) {
+        view?.keyboardWasHidden(notification: notification)
+    }
+
     func isLinked(to view: KeyboardObservable) -> Bool {
         guard let guardedView = self.view else {
             return false

--- a/Utils/Utils/KeyboardPresentable/KeyboardObservable.swift
+++ b/Utils/Utils/KeyboardPresentable/KeyboardObservable.swift
@@ -26,6 +26,12 @@ public protocol KeyboardObservable: class {
     /// This method is called when the keyboard disappears from the device screen
     func keyboardWillBeHidden(notification: Notification)
 
+    /// This method is called after the keyboard appears on the device screen. Optional Method
+    func keyboardWasShown(notification: Notification)
+
+    /// This method is called after the keyboard disappears from the device screen. Optional Method
+    func keyboardWasHidden(notification: Notification)
+
 }
 
 public extension KeyboardObservable {
@@ -46,11 +52,27 @@ public extension KeyboardObservable {
                            selector: #selector(KeyboardNotificationsObserver.keyboardWillBeHidden(notification:)),
                            name: UIResponder.keyboardWillHideNotification,
                            object: nil)
+        center.addObserver(notificationsObserver,
+                           selector: #selector(KeyboardNotificationsObserver.keyboardWasShown(notification:)),
+                           name: UIResponder.keyboardDidShowNotification,
+                           object: nil)
+        center.addObserver(notificationsObserver,
+                           selector: #selector(KeyboardNotificationsObserver.keyboardWasHidden(notification:)),
+                           name: UIResponder.keyboardDidHideNotification,
+                           object: nil)
     }
 
     func unsubscribeFromKeyboardNotifications() {
         KeyboardNotificationsObserverPool.shared.removeInvalid()
         KeyboardNotificationsObserverPool.shared.releaseObserver(for: self)
+    }
+
+    // MARK: - Optional Methods
+
+    func keyboardWasShown(notification: Notification) {
+    }
+
+    func keyboardWasHidden(notification: Notification) {
     }
 
 }


### PR DESCRIPTION
В общем, история началась с того, что обнаружили с Мишей следующее поведение: у UITextField сначала срабатывает метод делегата textFieldDidBeginEditing, потом показывается клавиатура (keyboardWillShow). У UITextView все наоборот. Единственный выход для Мишани был - выполнить часть своего кода на keyboardDidShow.

Но у KeyboardPresentable таких возможностей нет - потому и решено было добавить. Соответственно, появились методы типа "клава уже показалась" и "клава уже скрылась". Чтобы в текущем коде не надо было изменений делать (да и по опыту они не так часто нужны будут, эти методы) - добавил пустые реализации для них, типа `optional` методы :) Кто хочет - может заюзать.

У себя на проекте уже обкатал, вроде вызываются, код менять не пришлось, ничего не упало.