### PR TITLE
Add StringBuilder

### DIFF
--- a/SurfUtils.podspec
+++ b/SurfUtils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "SurfUtils"
-  s.version = "8.1.0"
+  s.version = "8.2.0"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:

--- a/SurfUtils.podspec
+++ b/SurfUtils.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
 
   s.subspec 'StringAttributes' do |sp|
-    sp.source_files = 'Utils/Utils/String/String+Attributes.swift'
+    sp.source_files = 'Utils/Utils/String/*.swift'
     sp.framework = 'Foundation', 'UIKit'
   end
 

--- a/Utils/Utils.xcodeproj/project.pbxproj
+++ b/Utils/Utils.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		90C101CA21E0B62D002E8E65 /* RouteMeasurerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C101C921E0B62D002E8E65 /* RouteMeasurerTests.swift */; };
 		A439074B21F5C52A0034C455 /* UIView+Masking.swift in Sources */ = {isa = PBXBuildFile; fileRef = A439074A21F5C52A0034C455 /* UIView+Masking.swift */; };
 		A439074E21F5C5880034C455 /* SkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A439074D21F5C5880034C455 /* SkeletonView.swift */; };
+		D6040DFC22C5F3E20088BB50 /* StringBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6040DFB22C5F3E20088BB50 /* StringBuilder.swift */; };
 		E9B0630A2146924A0080C391 /* VibrationFeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */; };
 		E9B0630C214692C30080C391 /* UIDevice+hasTapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */; };
 		E9B0630E214693160080C391 /* UIDevice+hasHapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */; };
@@ -69,6 +70,7 @@
 		90C101C921E0B62D002E8E65 /* RouteMeasurerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMeasurerTests.swift; sourceTree = "<group>"; };
 		A439074A21F5C52A0034C455 /* UIView+Masking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Masking.swift"; sourceTree = "<group>"; };
 		A439074D21F5C5880034C455 /* SkeletonView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkeletonView.swift; sourceTree = "<group>"; };
+		D6040DFB22C5F3E20088BB50 /* StringBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringBuilder.swift; sourceTree = "<group>"; };
 		E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrationFeedbackManager.swift; sourceTree = "<group>"; };
 		E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+hasTapticEngine.swift"; sourceTree = "<group>"; };
 		E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+hasHapticFeedback.swift"; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 			isa = PBXGroup;
 			children = (
 				4F3ED9FB211C27FD0030DD45 /* String+Attributes.swift */,
+				D6040DFB22C5F3E20088BB50 /* StringBuilder.swift */,
 			);
 			path = String;
 			sourceTree = "<group>";
@@ -384,6 +387,7 @@
 				18F2361421D2150200169AC9 /* Dictionary+QueryStringBuilder.swift in Sources */,
 				E9B063102147AECC0080C391 /* UIDevice+feedbackType.swift in Sources */,
 				9087BC5421EF3BF200FCE1E1 /* FullKeyboardPresentable.swift in Sources */,
+				D6040DFC22C5F3E20088BB50 /* StringBuilder.swift in Sources */,
 				902C67EC21E4D20B007B13CC /* ItemsScrollManager.swift in Sources */,
 				E9B0630A2146924A0080C391 /* VibrationFeedbackManager.swift in Sources */,
 				907F0FE621DCD3A0001CCB07 /* SettingsRouter.swift in Sources */,

--- a/Utils/Utils/String/StringBuilder.swift
+++ b/Utils/Utils/String/StringBuilder.swift
@@ -70,8 +70,8 @@ public class StringBuilder {
         let attributedString = NSMutableAttributedString()
 
         for var part in parts {
-            attributedString.append(NSAttributedString(string: part.string))
             part.addRange(NSRange(location: attributedString.length, length: part.string.count))
+            attributedString.append(NSAttributedString(string: part.string))
         }
 
         // add global attributes

--- a/Utils/Utils/String/StringBuilder.swift
+++ b/Utils/Utils/String/StringBuilder.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-final class StringBuilder {
+open class StringBuilder {
 
     // MARK: - Properties
 

--- a/Utils/Utils/String/StringBuilder.swift
+++ b/Utils/Utils/String/StringBuilder.swift
@@ -10,16 +10,15 @@ import Foundation
 
 public class StringBuilder {
 
+    // MARK: - Nested types
+
+    typealias StringPart = (string: String, attributes: [StringAttribute])
+
     // MARK: - Properties
 
     public var value: NSMutableAttributedString {
         get {
-            let attributedString = string
-            attributedString.addAttributes(
-                globalAttributes.toDictionary(),
-                range: NSRange(location: 0, length: attributedString.length)
-            )
-            return attributedString
+            return renderAttributedString()
         }
         set {
             string = newValue
@@ -29,6 +28,7 @@ public class StringBuilder {
     // MARK: - Private properties
 
     private var string = NSMutableAttributedString()
+    private var parts: [StringPart] = []
     private var globalAttributes: [StringAttribute] = []
 
     // MARK: - Initialization
@@ -53,8 +53,24 @@ public class StringBuilder {
 
     @discardableResult
     public func add(text: String, with attributes: [StringAttribute] = []) -> StringBuilder {
-        string.append(text.with(attributes: attributes))
+        parts.append((string: text, attributes: attributes))
         return self
+    }
+
+    // MARK: - Private methods
+
+    private func renderAttributedString() -> NSMutableAttributedString {
+        let attributedString = string
+        attributedString.addAttributes(
+            globalAttributes.toDictionary(),
+            range: NSRange(location: 0, length: attributedString.length)
+        )
+
+        for part in parts {
+            attributedString.append(part.string.with(attributes: part.attributes))
+        }
+
+        return attributedString
     }
 
 }

--- a/Utils/Utils/String/StringBuilder.swift
+++ b/Utils/Utils/String/StringBuilder.swift
@@ -1,0 +1,54 @@
+//
+//  StringBuilder.swift
+//  Utils
+//
+//  Created by Alexander Filimonov on 28/06/2019.
+//  Copyright © 2019 Surf. All rights reserved.
+//
+
+import Foundation
+
+final class StringBuilder {
+
+    // MARK: - Properties
+
+    var value: NSMutableAttributedString {
+        get {
+            let attributedString = string
+            attributedString.addAttributes(
+                globalAttributes.toDictionary(),
+                range: NSRange(location: 0, length: attributedString.length)
+            )
+            return attributedString
+        }
+        set {
+            string = newValue
+        }
+    }
+
+    // MARK: - Private properties
+
+    private var string = NSMutableAttributedString()
+    private var globalAttributes: [StringAttribute] = []
+
+    // MARK: - Public methods
+
+    @discardableResult
+    public func clear() -> StringBuilder {
+        value = NSMutableAttributedString()
+        return self
+    }
+
+    @discardableResult
+    public func add(attributes: [StringAttribute]) -> StringBuilder {
+        self.globalAttributes = attributes
+        return self
+    }
+
+    @discardableResult
+    public func add(text: String, with attributed: [StringAttribute]) -> StringBuilder {
+        string.append(text.with(attributes: attributed))
+        return self
+    }
+
+}

--- a/Utils/Utils/String/StringBuilder.swift
+++ b/Utils/Utils/String/StringBuilder.swift
@@ -12,18 +12,14 @@ public class StringBuilder {
 
     // MARK: - Nested types
 
-    struct StringPart {
+    class StringPart {
         let string: String
         let attributes: [StringAttribute]
         var range: NSRange?
 
-        init(string: String, attributes: [StringAttribute]) {
+        init(string: String, attributes: [StringAttribute] = []) {
             self.string = string
             self.attributes = attributes
-        }
-
-        mutating func addRange(_ range: NSRange) {
-            self.range = range
         }
     }
 
@@ -64,13 +60,25 @@ public class StringBuilder {
         return self
     }
 
+    @discardableResult
+    public func addSpace() -> StringBuilder {
+        parts.append(StringPart(string: " "))
+        return self
+    }
+
+    @discardableResult
+    public func addLineBreak() -> StringBuilder {
+        parts.append(StringPart(string: "\n"))
+        return self
+    }
+
     // MARK: - Private methods
 
     private func renderAttributedString() -> NSMutableAttributedString {
         let attributedString = NSMutableAttributedString()
 
-        for var part in parts {
-            part.addRange(NSRange(location: attributedString.length, length: part.string.count))
+        for part in parts {
+            part.range = NSRange(location: attributedString.length, length: part.string.count)
             attributedString.append(NSAttributedString(string: part.string))
         }
 

--- a/Utils/Utils/String/StringBuilder.swift
+++ b/Utils/Utils/String/StringBuilder.swift
@@ -12,7 +12,7 @@ public class StringBuilder {
 
     // MARK: - Properties
 
-    var value: NSMutableAttributedString {
+    public var value: NSMutableAttributedString {
         get {
             let attributedString = string
             attributedString.addAttributes(

--- a/Utils/Utils/String/StringBuilder.swift
+++ b/Utils/Utils/String/StringBuilder.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// Class for building NSAttributedString with different styles for different parts
 public class StringBuilder {
 
     // MARK: - Nested types
@@ -23,6 +24,11 @@ public class StringBuilder {
         }
     }
 
+    private enum Constants {
+        static let breakSymbol = "\n"
+        static let spaceSymbol = " "
+    }
+
     // MARK: - Readonly properties
 
     public var value: NSMutableAttributedString {
@@ -36,8 +42,8 @@ public class StringBuilder {
 
     // MARK: - Initialization
 
-    public init(attributes: [StringAttribute] = []) {
-        self.globalAttributes = attributes
+    public init(globalAttributes: [StringAttribute] = []) {
+        self.globalAttributes = globalAttributes
     }
 
     // MARK: - Public methods
@@ -49,8 +55,8 @@ public class StringBuilder {
     }
 
     @discardableResult
-    public func add(attributes: [StringAttribute]) -> StringBuilder {
-        self.globalAttributes.append(contentsOf: attributes)
+    public func add(globalAttributes: [StringAttribute]) -> StringBuilder {
+        self.globalAttributes.append(contentsOf: globalAttributes)
         return self
     }
 
@@ -62,21 +68,21 @@ public class StringBuilder {
 
     @discardableResult
     public func addSpace() -> StringBuilder {
-        parts.append(StringPart(string: " "))
+        parts.append(StringPart(string: Constants.spaceSymbol))
         return self
     }
 
     @discardableResult
     public func addLineBreak() -> StringBuilder {
-        parts.append(StringPart(string: "\n"))
+        parts.append(StringPart(string: Constants.breakSymbol))
         return self
     }
 
     // MARK: - Private methods
 
     private func renderAttributedString() -> NSMutableAttributedString {
+        // combline attributedString
         let attributedString = NSMutableAttributedString()
-
         for part in parts {
             part.range = NSRange(location: attributedString.length, length: part.string.count)
             attributedString.append(NSAttributedString(string: part.string))

--- a/Utils/Utils/String/StringBuilder.swift
+++ b/Utils/Utils/String/StringBuilder.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-open class StringBuilder {
+public class StringBuilder {
 
     // MARK: - Properties
 
@@ -31,6 +31,12 @@ open class StringBuilder {
     private var string = NSMutableAttributedString()
     private var globalAttributes: [StringAttribute] = []
 
+    // MARK: - Initialization
+
+    public init(attributes: [StringAttribute] = []) {
+        self.globalAttributes = attributes
+    }
+
     // MARK: - Public methods
 
     @discardableResult
@@ -41,13 +47,13 @@ open class StringBuilder {
 
     @discardableResult
     public func add(attributes: [StringAttribute]) -> StringBuilder {
-        self.globalAttributes = attributes
+        self.globalAttributes.append(contentsOf: attributes)
         return self
     }
 
     @discardableResult
-    public func add(text: String, with attributed: [StringAttribute]) -> StringBuilder {
-        string.append(text.with(attributes: attributed))
+    public func add(text: String, with attributes: [StringAttribute] = []) -> StringBuilder {
+        string.append(text.with(attributes: attributes))
         return self
     }
 


### PR DESCRIPTION
Add class `StringBuilder` to simplify creating complicated `NSAttributedString` with different attributes for different parts of text. 

There are two types of attributes: local and global. In initialisation time you add global. With `add(text: String, attributes: [StringAttribute])` you add local styles.

Render into `attributeString` perfoms only in time of acmes to `value` property. 

Syntax:
```swift
let attributedString = StringBuilder(
    attributes: [
      .font(FontFamily.MyFont.regular.font(size: 24)),
      .foregroundColor(Color.Main.blackText)
    ]
  )
  .add(text: "12", with: [
    .font(FontFamily.MyFont.regular.font(size: 36)),
    .foregroundColor(Color.Main.redError)
  ])
  .addSpace()
  .add(text: "месяцев")
  .addLineBreak()
  .add(text: "green", with: [
    .foregroundColor(.green)
  ])
  .value
```