### PR TITLE
remove private API

### DIFF
--- a/SurfUtils.podspec
+++ b/SurfUtils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "SurfUtils"
-  s.version = "8.2.0"
+  s.version = "9.0.0"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:

--- a/Utils/Utils/SettingsRouter/SettingsRouter.swift
+++ b/Utils/Utils/SettingsRouter/SettingsRouter.swift
@@ -14,7 +14,6 @@ public final class SettingsRouter {
     // MARK: - Constants
 
     private enum Constants {
-        static let deviceSettingsUrl = "App-prefs:root=General"
         static let appSettingsUrl = UIApplication.openSettingsURLString
     }
 
@@ -26,14 +25,6 @@ public final class SettingsRouter {
         }
         openExpectedURL(url)
     }
-
-    public static func openDeviceSettings() {
-        guard let url = URL(string: Constants.deviceSettingsUrl) else {
-            return
-        }
-        openExpectedURL(url)
-    }
-
 }
 
 // MARK: - Private Methods


### PR DESCRIPTION
```
Guideline 2.5.1 - Performance - Software Requirements
Your app uses the “prefs:root=” non-public URL scheme, which is a private entity. The use of non-public APIs is not permitted on the App Store because it can lead to a poor user experience should these APIs change.
Continuing to use or conceal non-public APIs in future submissions of this app may result in the termination of your Apple Developer account, as well as removal of all associated apps from the App Store.
Next Steps
To resolve this issue, please revise your app to provide the associated functionality using public APIs or remove the functionality using the “prefs:root” or “App-Prefs:root” URL scheme.
```
