### PR TITLE
#35 rename jail break detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pod 'SurfUtils/$UTIL_NAME$', :git => "https://github.com/surfstudio/iOS-Utils.gi
 ## Список утилит
 
 - [StringAttributes](#stringattributes) - упрощение работы с `NSAttributedString`
-- [JailbreakDetect](#jailbreakdetect) - позволяет определить наличие root на девайсе.
+- [BrightSide](#brightside) - позволяет определить наличие root на девайсе.
 - [VibrationFeedbackManager](#vibrationfeedbackmanager) - позволяет воспроизвести вибрацию на устройстве.
 - [QueryStringBuilder](#querystringbuilder) - построение строки с параметрами из словаря
 - [BlurBuilder](#blurbuilder) - упрощение работы с blur-эффектом
@@ -41,16 +41,16 @@ pod 'SurfUtils/$UTIL_NAME$', :git => "https://github.com/surfstudio/iOS-Utils.gi
 let attrString = "Awesome attributed srting".with(attributes: [.kern(9), lineHeight(20)])
 ```
 
-### JailbreakDetect
+### BrightSide
 
 Утилита позволяет определить наличие root на устройстве.
 
 Пример:
 ```Swift
-if JailbreakDetect.isJailBroken() {
-    print("На девайсе установлен jailbreak")
+if BrightSide.isWhiteDevice() {
+    print("Девайс чист как белый лист")
 } else {
-    print("Девайс чист")
+    print("На девайсе получен root доступ")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ let attrString = "Awesome attributed srting".with(attributes: [.kern(9), lineHei
 
 Пример:
 ```Swift
-if BrightSide.isWhiteDevice() {
+if BrightSide.isBright() {
     print("Девайс чист как белый лист")
 } else {
     print("На девайсе получен root доступ")

--- a/SurfUtils.podspec
+++ b/SurfUtils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "SurfUtils"
-  s.version = "9.0.1"
+  s.version = "10.0.0"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:

--- a/Utils/Utils.xcodeproj/project.pbxproj
+++ b/Utils/Utils.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		4F3ED9E9211C27CF0030DD45 /* Utils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F3ED9DF211C27CF0030DD45 /* Utils.framework */; };
 		4F3ED9F0211C27CF0030DD45 /* Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F3ED9E2211C27CF0030DD45 /* Utils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F3ED9FC211C27FD0030DD45 /* String+Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F3ED9FB211C27FD0030DD45 /* String+Attributes.swift */; };
-		80437D26214045EF0095A8D0 /* JailbreakDetect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80437D25214045EF0095A8D0 /* JailbreakDetect.swift */; };
+		80437D26214045EF0095A8D0 /* BrightSide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80437D25214045EF0095A8D0 /* BrightSide.swift */; };
 		8953A46D23560A2F007AD110 /* OTPField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8953A46C23560A2F007AD110 /* OTPField.swift */; };
 		8953A46F23560A4C007AD110 /* OTPField.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8953A46E23560A4C007AD110 /* OTPField.xib */; };
 		898845202360482D004940DC /* UIView+XibSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8988451F2360482D004940DC /* UIView+XibSetup.swift */; };
@@ -59,7 +59,7 @@
 		4F3ED9E8211C27CF0030DD45 /* UtilsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UtilsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F3ED9EF211C27CF0030DD45 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4F3ED9FB211C27FD0030DD45 /* String+Attributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Attributes.swift"; sourceTree = "<group>"; };
-		80437D25214045EF0095A8D0 /* JailbreakDetect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JailbreakDetect.swift; sourceTree = "<group>"; };
+		80437D25214045EF0095A8D0 /* BrightSide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightSide.swift; sourceTree = "<group>"; };
 		8953A46C23560A2F007AD110 /* OTPField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPField.swift; sourceTree = "<group>"; };
 		8953A46E23560A4C007AD110 /* OTPField.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OTPField.xib; sourceTree = "<group>"; };
 		8988451F2360482D004940DC /* UIView+XibSetup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+XibSetup.swift"; sourceTree = "<group>"; };
@@ -139,7 +139,7 @@
 			children = (
 				18F2361221D214CC00169AC9 /* Dictionary */,
 				902C67EA21E4D1EF007B13CC /* ItemsScrollManager */,
-				80437D24214045B30095A8D0 /* JailbreakDetect */,
+				80437D24214045B30095A8D0 /* BrightSide */,
 				90718AED21EA36CA00C81002 /* KeyboardPresentable */,
 				907F0FEA21DCD7C6001CCB07 /* RouteMeasurer */,
 				907F0FE421DCD375001CCB07 /* SettingsRouter */,
@@ -175,12 +175,12 @@
 			path = String;
 			sourceTree = "<group>";
 		};
-		80437D24214045B30095A8D0 /* JailbreakDetect */ = {
+		80437D24214045B30095A8D0 /* BrightSide */ = {
 			isa = PBXGroup;
 			children = (
-				80437D25214045EF0095A8D0 /* JailbreakDetect.swift */,
+				80437D25214045EF0095A8D0 /* BrightSide.swift */,
 			);
-			path = JailbreakDetect;
+			path = BrightSide;
 			sourceTree = "<group>";
 		};
 		8953A46B23560726007AD110 /* OTPField */ = {
@@ -422,7 +422,7 @@
 				89F23A69235733BC005112E1 /* DigitField.swift in Sources */,
 				E9B0630C214692C30080C391 /* UIDevice+hasTapticEngine.swift in Sources */,
 				A439074E21F5C5880034C455 /* SkeletonView.swift in Sources */,
-				80437D26214045EF0095A8D0 /* JailbreakDetect.swift in Sources */,
+				80437D26214045EF0095A8D0 /* BrightSide.swift in Sources */,
 				898845202360482D004940DC /* UIView+XibSetup.swift in Sources */,
 				9087BC5221EF3BE700FCE1E1 /* CommonKeyboardPresentable.swift in Sources */,
 				9087BC5021EF3BD400FCE1E1 /* KeyboardObservable.swift in Sources */,

--- a/Utils/Utils/BrightSide/BrightSide.swift
+++ b/Utils/Utils/BrightSide/BrightSide.swift
@@ -16,12 +16,12 @@ public final class BrightSide {
     public static func isWhiteDevice() -> Bool {
         // Check 1 : check if current device is simulator
         if isSimulator() {
-            return false
+            return true
         }
 
         // Check 2 : existence of files that are common for jailbroken devices
         if isJailbreakDirectoriesExist() || canOpenCydia() {
-            return true
+            return false
         }
 
         // Check 3 : Reading and writing in system directories (sandbox violation)
@@ -31,9 +31,9 @@ public final class BrightSide {
                                     atomically: true,
                                     encoding: String.Encoding.utf8)
             //Device is jailbroken
-            return true
-        } catch {
             return false
+        } catch {
+            return true
         }
     }
 

--- a/Utils/Utils/BrightSide/BrightSide.swift
+++ b/Utils/Utils/BrightSide/BrightSide.swift
@@ -1,5 +1,5 @@
 //
-//  JailbreakDetect.swift
+//  BrightSide.swift
 //  Utils
 //
 //  Created by Vlad Krupenko on 05.09.2018.
@@ -8,12 +8,12 @@
 
 import Foundation
 
-public final class JailbreakDetect {
+public final class BrightSide {
 
-    // MARK: - Internal static methods
+    // MARK: - Public static methods
 
     /// Method return true, if we can detect some common for jailbroken deivce files or can write to device
-    public static func isJailBroken() -> Bool {
+    public static func isWhiteDevice() -> Bool {
         // Check 1 : check if current device is simulator
         if isSimulator() {
             return false
@@ -41,7 +41,7 @@ public final class JailbreakDetect {
 
 // MARK: - Private help methods
 
-private extension JailbreakDetect {
+private extension BrightSide {
 
     /// Method will return true, if any of the files typical for the jailbreak exists
     private static func isJailbreakDirectoriesExist() -> Bool {

--- a/Utils/Utils/BrightSide/BrightSide.swift
+++ b/Utils/Utils/BrightSide/BrightSide.swift
@@ -12,7 +12,7 @@ public final class BrightSide {
 
     // MARK: - Public static methods
 
-    /// Method return true, if we can detect some common for jailbroken deivce files or can write to device
+    /// Method return false, if we can detect some common for jailbroken deivce files or can write to device
     public static func isWhiteDevice() -> Bool {
         // Check 1 : check if current device is simulator
         if isSimulator() {

--- a/Utils/Utils/BrightSide/BrightSide.swift
+++ b/Utils/Utils/BrightSide/BrightSide.swift
@@ -13,7 +13,7 @@ public final class BrightSide {
     // MARK: - Public static methods
 
     /// Method return false, if we can detect some common for jailbroken deivce files or can write to device
-    public static func isWhiteDevice() -> Bool {
+    public static func isBright() -> Bool {
         // Check 1 : check if current device is simulator
         if isSimulator() {
             return true


### PR DESCRIPTION
@LastSprint заводил [issue](https://github.com/surfstudio/iOS-Utils/issues/35), с целью переименовать метод, чтобы его нельзя было явно определить при реверсе.   

Моей фантазии хватило только на это название. 