### PR TITLE
Добавил crossOut в StringAttribute

### DIFF
--- a/SurfUtils.podspec
+++ b/SurfUtils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "SurfUtils"
-  s.version = "10.0.1"
+  s.version = "10.0.2"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:

--- a/Utils/Utils/String/String+Attributes.swift
+++ b/Utils/Utils/String/String+Attributes.swift
@@ -21,13 +21,38 @@ public enum StringAttribute {
     case foregroundColor(UIColor)
     /// Text aligment
     case aligment(NSTextAlignment)
+    /// Test crossing out
+    case crossOut(style: CrossOutStyle)
 
     /// Figma friendly case means that lineSpacing = lineHeight - font.lineHeight
     /// This case provide possibility to set both `font` and `lineSpacing`
     /// First parameter is Font and second parameter is lineHeight property from Figma
     /// For more details see [#14](https://github.com/surfstudio/iOS-Utils/issues/14)
     case lineHeight(CGFloat, font: UIFont)
+}
 
+// MARK: - Nested types
+
+extension StringAttribute{
+    /// Enum for configuring style of crossOut text
+    public enum CrossOutStyle {
+        case single
+        case double
+
+        var coreValue: NSUnderlineStyle {
+            switch self {
+            case .double:
+                return NSUnderlineStyle.double
+            case .single:
+                return NSUnderlineStyle.single
+            }
+        }
+    }
+}
+
+// MARK: - StringAttribute extension
+
+extension StringAttribute {
     var attributeKey: NSAttributedString.Key {
         switch self {
         case .lineSpacing, .aligment, .lineHeight:
@@ -38,6 +63,8 @@ public enum StringAttribute {
             return NSAttributedString.Key.font
         case .foregroundColor:
             return NSAttributedString.Key.foregroundColor
+        case .crossOut:
+            return NSAttributedString.Key.strikethroughStyle
         }
     }
 
@@ -55,17 +82,22 @@ public enum StringAttribute {
             return value
         case .lineHeight(let lineHeight, let font):
             return lineHeight - font.lineHeight
+        case .crossOut(let style):
+            return style.coreValue.rawValue
         }
     }
 }
 
-public extension String {
+// MARK: - String extension
 
+public extension String {
     /// Apply attributes to string and returns new attributes string
     func with(attributes: [StringAttribute]) -> NSAttributedString {
         return NSAttributedString(string: self, attributes: attributes.toDictionary())
     }
 }
+
+// MARK: - Private array extension
 
 private extension Array where Element == StringAttribute {
     func normalizedAttributes() -> [StringAttribute] {
@@ -82,6 +114,8 @@ private extension Array where Element == StringAttribute {
         return result
     }
 }
+
+// MARK: - Public array extension
 
 public extension Array where Element == StringAttribute {
     func toDictionary() -> [NSAttributedString.Key: Any] {

--- a/Utils/Utils/String/String+Attributes.swift
+++ b/Utils/Utils/String/String+Attributes.swift
@@ -21,7 +21,7 @@ public enum StringAttribute {
     case foregroundColor(UIColor)
     /// Text aligment
     case aligment(NSTextAlignment)
-    /// Test crossing out
+    /// Text crossing out
     case crossOut(style: CrossOutStyle)
 
     /// Figma friendly case means that lineSpacing = lineHeight - font.lineHeight


### PR DESCRIPTION
`.crossOut` атрибут дает возможность перечеркнуть текст в `UILabel` (желательно использовать только если во всем тексте используется один и тот же шрифт, иначе будет прыгающая черта). 

## Пример

```swift
label.attributedText = "12 200 р".with(attributes: [.crossOut])
```

## Результат
~~12 200 р~~
