### PR TITLE
Добавил удаление слоя градиента перед его инициализацией

### DIFF
--- a/SurfUtils.podspec
+++ b/SurfUtils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "SurfUtils"
-  s.version = "10.0.3"
+  s.version = "10.0.4"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:

--- a/Utils/Utils/SkeletonView/SkeletonView.swift
+++ b/Utils/Utils/SkeletonView/SkeletonView.swift
@@ -85,6 +85,7 @@ open class SkeletonView: UIView {
 
     override open func draw(_ rect: CGRect) {
         super.draw(rect)
+        removeGradientLayerIfNeeded()
         configureGradientLayer()
         updateColors()
         maskingViews = subviews
@@ -142,6 +143,11 @@ private extension SkeletonView {
             gradientMovingColor.cgColor,
             gradientBackgroundColor.cgColor
         ]
+    }
+
+    func removeGradientLayerIfNeeded() {
+        gradientLayer?.removeFromSuperlayer()
+        gradientLayer = nil
     }
 
     func configureGradientLayer() {


### PR DESCRIPTION
В проекте заметили проблему: добавили `SkeletonView` в footer секции `collectionView` и каждый раз когда появлялся footer запускалась анимация, а старая не удалялось. 
Как оказалось каждый раз вызывался `draw`, при вызове которого добавлялся новый слой градиента и не удалялся старый. 
Проблема решена удалением старого слоя градиента перед добавлением нового.