### PR TITLE
#70 Fix moneymodel as string

### DIFF
--- a/Utils/Utils/MoneyModel/MoneyModel.swift
+++ b/Utils/Utils/MoneyModel/MoneyModel.swift
@@ -93,8 +93,12 @@ extension MoneyModel {
     /// Конвертирует модель в строку вида `рубли.копейки`
     /// Если digit == 0 то вернет просто `рубли`
     func asString() -> String {
-
-        let digitPart = self.digit == 0 ? "" : ".\(self.digit)"
+        let digitPart: String = {
+            guard digit > 0 else {
+                return ""
+            }
+            return digit < 10 ? ".0\(self.digit)" : ".\(self.digit)"
+        }()
 
         return "\(self.decimal)\(digitPart)"
     }

--- a/Utils/UtilsTests/MoneyModelTests.swift
+++ b/Utils/UtilsTests/MoneyModelTests.swift
@@ -230,4 +230,15 @@ final class MoneyModelTests: XCTestCase {
 
         XCTAssertNil(res)
     }
+
+    /// Тест форматирования - никаких округлений
+    func testAsStringFormatting() {
+
+        XCTAssertEqual(MoneyModel(decimal: 10, digit: 0).asString(), "10")
+
+        XCTAssertEqual(MoneyModel(decimal: 10, digit: 9).asString(), "10.09")
+
+        XCTAssertEqual(MoneyModel(decimal: 10, digit: 99).asString(), "10.99")
+
+    }
 }


### PR DESCRIPTION
Fixes #70 
Правки форматирования `MoneyModel.asString()` и юнит-тесты на эти кейсы