### PR TITLE
Исправить конфликт swift 5.4 в xcode 12.5 и CryptoSwift 1.3.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift",
         "state": {
           "branch": null,
-          "revision": "39f08ac5269361a50c08ce1e2f41989bfc4b1ec8",
-          "version": "1.3.1"
+          "revision": "4e31051c63cc0ddf10a25cf5318856c510cf77f4",
+          "version": "1.4.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(
             name: "CryptoSwift",
             url: "https://github.com/krzyzanowskim/CryptoSwift",
-            .exact("1.3.1")
+            .exact("1.4.0")
         ),
         .package(
             name: "Device",

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Utils",
-    platforms: [.iOS(.v11)],
+    platforms: [.iOS(.v11), .macOS(.v10_12)],
     products: [
         .library(
             name: "Utils",

--- a/SurfUtils.podspec
+++ b/SurfUtils.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "SurfUtils"
-  s.version = "11.1.0"
+  s.version = "11.1.2"
   s.summary = "Contains a set of utils in subspecs"
   s.description  = <<-DESC
   Contains:
@@ -137,7 +137,7 @@ Pod::Spec.new do |s|
   s.subspec 'SecurityService' do |sp|
     sp.source_files = 'Utils/Utils/SecurityService/**/*.swift'
     sp.framework = 'Foundation'
-    sp.dependency 'CryptoSwift', '1.3.1'
+    sp.dependency 'CryptoSwift', '1.4.0'
   end
 
   s.subspec 'BeanPageControl' do |sp|

--- a/Utils/Podfile
+++ b/Utils/Podfile
@@ -12,7 +12,7 @@ def common_pods
 	utils
 
 	pod 'Device', '3.1.2'
-  pod 'CryptoSwift', :git => 'https://github.com/krzyzanowskim/CryptoSwift', :tag => '1.3.1'
+  pod 'CryptoSwift', :git => 'https://github.com/krzyzanowskim/CryptoSwift', :tag => '1.4.0'
 end 
 
 target 'Utils' do

--- a/Utils/Utils.xcodeproj/project.pbxproj
+++ b/Utils/Utils.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		573117D623BF889000491781 /* LayoutHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573117D523BF889000491781 /* LayoutHelper.swift */; };
 		573117D923BFD28300491781 /* UIStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573117D823BFD28300491781 /* UIStyle.swift */; };
 		573117DB23BFD33000491781 /* AnyStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573117DA23BFD33000491781 /* AnyStyle.swift */; };
+		579EAFCC27022F1E004E092B /* VibrationFeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579EAFCB27022F1E004E092B /* VibrationFeedbackManager.swift */; };
+		579EAFCE27022F47004E092B /* GeolocationServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579EAFCD27022F47004E092B /* GeolocationServiceInterface.swift */; };
 		80437D26214045EF0095A8D0 /* BrightSide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80437D25214045EF0095A8D0 /* BrightSide.swift */; };
 		8482FBCBA27F82821D280001 /* Pods_Utils_UtilsTestsHost.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6001AEDB12999C2AB2149381 /* Pods_Utils_UtilsTestsHost.framework */; };
 		87239D7F24D41E8700D38EC7 /* MoneyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87239D7E24D41E8700D38EC7 /* MoneyModel.swift */; };
@@ -77,7 +79,6 @@
 		9087BC5621EF3BFB00FCE1E1 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9087BC5521EF3BFB00FCE1E1 /* Notification.swift */; };
 		9087BC5A21EF6C9F00FCE1E1 /* KeyboardNotificationsObserverPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9087BC5921EF6C9F00FCE1E1 /* KeyboardNotificationsObserverPool.swift */; };
 		90AC85612385928100DF7F3B /* GeolocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90AC85602385928100DF7F3B /* GeolocationService.swift */; };
-		90AC85632385928E00DF7F3B /* GeolocationServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90AC85622385928E00DF7F3B /* GeolocationServiceInterface.swift */; };
 		90AC85652385929E00DF7F3B /* LocationManagerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90AC85642385929E00DF7F3B /* LocationManagerInterface.swift */; };
 		90AC8567238592A700DF7F3B /* GeolocationAccuracy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90AC8566238592A700DF7F3B /* GeolocationAccuracy.swift */; };
 		90AC8569238592AF00DF7F3B /* GeolocationAuthResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90AC8568238592AF00DF7F3B /* GeolocationAuthResult.swift */; };
@@ -99,7 +100,6 @@
 		C11CEB4724D44E2C00C1CD0F /* MailSenderPayloadProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11CEB4124D44E2C00C1CD0F /* MailSenderPayloadProvider.swift */; };
 		C11CEB4824D44E2C00C1CD0F /* MailSenderRouterHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11CEB4224D44E2C00C1CD0F /* MailSenderRouterHelper.swift */; };
 		D6040DFC22C5F3E20088BB50 /* StringBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6040DFB22C5F3E20088BB50 /* StringBuilder.swift */; };
-		E9B0630A2146924A0080C391 /* VibrationFeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */; };
 		E9B0630C214692C30080C391 /* UIDevice+hasTapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */; };
 		E9B0630E214693160080C391 /* UIDevice+hasHapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */; };
 		E9B063102147AECC0080C391 /* UIDevice+feedbackType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B0630F2147AECC0080C391 /* UIDevice+feedbackType.swift */; };
@@ -184,6 +184,8 @@
 		573117D523BF889000491781 /* LayoutHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutHelper.swift; sourceTree = "<group>"; };
 		573117D823BFD28300491781 /* UIStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStyle.swift; sourceTree = "<group>"; };
 		573117DA23BFD33000491781 /* AnyStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyStyle.swift; sourceTree = "<group>"; };
+		579EAFCB27022F1E004E092B /* VibrationFeedbackManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VibrationFeedbackManager.swift; sourceTree = "<group>"; };
+		579EAFCD27022F47004E092B /* GeolocationServiceInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeolocationServiceInterface.swift; sourceTree = "<group>"; };
 		6001AEDB12999C2AB2149381 /* Pods_Utils_UtilsTestsHost.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Utils_UtilsTestsHost.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		632D58609B21028A5FFDF22F /* Pods-Utils.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Utils.debug.xcconfig"; path = "Target Support Files/Pods-Utils/Pods-Utils.debug.xcconfig"; sourceTree = "<group>"; };
 		80437D25214045EF0095A8D0 /* BrightSide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightSide.swift; sourceTree = "<group>"; };
@@ -210,7 +212,6 @@
 		9087BC5521EF3BFB00FCE1E1 /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
 		9087BC5921EF6C9F00FCE1E1 /* KeyboardNotificationsObserverPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardNotificationsObserverPool.swift; sourceTree = "<group>"; };
 		90AC85602385928100DF7F3B /* GeolocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeolocationService.swift; sourceTree = "<group>"; };
-		90AC85622385928E00DF7F3B /* GeolocationServiceInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeolocationServiceInterface.swift; sourceTree = "<group>"; };
 		90AC85642385929E00DF7F3B /* LocationManagerInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManagerInterface.swift; sourceTree = "<group>"; };
 		90AC8566238592A700DF7F3B /* GeolocationAccuracy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeolocationAccuracy.swift; sourceTree = "<group>"; };
 		90AC8568238592AF00DF7F3B /* GeolocationAuthResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeolocationAuthResult.swift; sourceTree = "<group>"; };
@@ -236,7 +237,6 @@
 		CB0A89DF1B751C2D2CAC7179 /* Pods_Utils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Utils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D06F434CB242A683A6DFCEC4 /* Pods-Utils.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Utils.release.xcconfig"; path = "Target Support Files/Pods-Utils/Pods-Utils.release.xcconfig"; sourceTree = "<group>"; };
 		D6040DFB22C5F3E20088BB50 /* StringBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringBuilder.swift; sourceTree = "<group>"; };
-		E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrationFeedbackManager.swift; sourceTree = "<group>"; };
 		E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+hasTapticEngine.swift"; sourceTree = "<group>"; };
 		E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+hasHapticFeedback.swift"; sourceTree = "<group>"; };
 		E9B0630F2147AECC0080C391 /* UIDevice+feedbackType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+feedbackType.swift"; sourceTree = "<group>"; };
@@ -650,8 +650,8 @@
 		90AC855D2385924600DF7F3B /* GeolocationService */ = {
 			isa = PBXGroup;
 			children = (
+				579EAFCD27022F47004E092B /* GeolocationServiceInterface.swift */,
 				90AC855F2385927300DF7F3B /* Support */,
-				90AC85622385928E00DF7F3B /* GeolocationServiceInterface.swift */,
 				90AC85602385928100DF7F3B /* GeolocationService.swift */,
 			);
 			path = GeolocationService;
@@ -751,7 +751,7 @@
 		E9B06306214691F30080C391 /* VibrationFeedbackManager */ = {
 			isa = PBXGroup;
 			children = (
-				E9B063092146924A0080C391 /* VibrationFeedbackManager.swift */,
+				579EAFCB27022F1E004E092B /* VibrationFeedbackManager.swift */,
 				E9B0630B214692C30080C391 /* UIDevice+hasTapticEngine.swift */,
 				E9B0630D214693160080C391 /* UIDevice+hasHapticFeedback.swift */,
 				E9B0630F2147AECC0080C391 /* UIDevice+feedbackType.swift */,
@@ -1068,12 +1068,8 @@
 				3971F71C24F1843000597F9D /* CryptoCommon.swift in Sources */,
 				573117D623BF889000491781 /* LayoutHelper.swift in Sources */,
 				C11CEB4624D44E2C00C1CD0F /* MailSenderError.swift in Sources */,
-				90AC85632385928E00DF7F3B /* GeolocationServiceInterface.swift in Sources */,
-				E9B0630A2146924A0080C391 /* VibrationFeedbackManager.swift in Sources */,
 				C11CEB3B24D44DFA00C1CD0F /* MailUtil.swift in Sources */,
 				A4D5D5FD24E57A6A004ABFBC /* CustomSwitch.swift in Sources */,
-				90AC85632385928E00DF7F3B /* GeolocationServiceInterface.swift in Sources */,
-				E9B0630A2146924A0080C391 /* VibrationFeedbackManager.swift in Sources */,
 				3946575524EC1E600069BDB0 /* BaseLoadingView.swift in Sources */,
 				907F0FE621DCD3A0001CCB07 /* SettingsRouter.swift in Sources */,
 				3946575924EC21350069BDB0 /* LoadingSubview.swift in Sources */,
@@ -1083,6 +1079,7 @@
 				3971F72524F1843900597F9D /* SecureStore.swift in Sources */,
 				3971F72324F1843900597F9D /* InMemorySecureStore.swift in Sources */,
 				A439074E21F5C5880034C455 /* SkeletonView.swift in Sources */,
+				579EAFCC27022F1E004E092B /* VibrationFeedbackManager.swift in Sources */,
 				3971F72424F1843900597F9D /* GenericPasswordQueryable.swift in Sources */,
 				3971F71924F1842A00597F9D /* SHA3.swift in Sources */,
 				80437D26214045EF0095A8D0 /* BrightSide.swift in Sources */,
@@ -1090,6 +1087,7 @@
 				898845202360482D004940DC /* UIView+XibSetup.swift in Sources */,
 				90AC8567238592A700DF7F3B /* GeolocationAccuracy.swift in Sources */,
 				5709EC5D236F4C6500EEBD93 /* CommonButton.swift in Sources */,
+				579EAFCE27022F47004E092B /* GeolocationServiceInterface.swift in Sources */,
 				9087BC5221EF3BE700FCE1E1 /* CommonKeyboardPresentable.swift in Sources */,
 				3971F71524F1842300597F9D /* SymmetricCryptoService.swift in Sources */,
 				9087BC5021EF3BD400FCE1E1 /* KeyboardObservable.swift in Sources */,


### PR DESCRIPTION
Обвновлена версия CryptoSwift до 1.4.0 в подах и в spm, для работы с swift 5.4 в xcode 12.5 
Обвновлена версия Utils  до 11.1.2