### PR TITLE
Исправление бага с lineHeight в String Attributes 

### DIFF
--- a/Utils/Utils/String/String+Attributes.swift
+++ b/Utils/Utils/String/String+Attributes.swift
@@ -11,7 +11,7 @@ import UIKit
 
 /// Attributes for string.
 public enum StringAttribute {
-    /// Text line spacing
+    /// Text line spacing (paragraphStyle.lineSpacing)
     case lineSpacing(CGFloat)
     /// Letter spacing
     case kern(CGFloat)
@@ -27,7 +27,10 @@ public enum StringAttribute {
     case lineBreakMode(NSLineBreakMode)
     /// Text base line offset (vertical)
     case baselineOffset(CGFloat)
-    /// Text line height
+    /// Text line height, in points.
+    ///
+    /// If you also specify `.font` value, then will be used `paragraph.lineHeightMultiple`,
+    /// otherwise - `paragraph.minimumLineHeight` and `paragraph.maximumLineHeight`
     case lineHeight(CGFloat)
 }
 
@@ -155,17 +158,16 @@ public extension String {
     }
 }
 
-// MARK: - Public array extension
+// MARK: - Array extension
 
 public extension Array where Element == StringAttribute {
     func toDictionary() -> [NSAttributedString.Key: Any] {
         var resultAttributes = [NSAttributedString.Key: Any]()
         let paragraph = NSMutableParagraphStyle()
-        let font = self.findFont()
         for attribute in self {
             switch attribute {
             case .lineHeight(let lineHeight):
-                if let font = font {
+                if let font = self.findFont() {
                     paragraph.lineHeightMultiple = lineHeight / font.lineHeight
                 } else {
                     paragraph.minimumLineHeight = lineHeight
@@ -188,6 +190,9 @@ public extension Array where Element == StringAttribute {
         return resultAttributes
     }
 
+    // MARK: - Private Methods
+
+    /// Returns font from array of StringAttributes, if it exists, and nil otherwise
     private func findFont() -> UIFont? {
         for value in self {
             if case .font(let font) = value {

--- a/Utils/Utils/String/String+Attributes.swift
+++ b/Utils/Utils/String/String+Attributes.swift
@@ -27,12 +27,8 @@ public enum StringAttribute {
     case lineBreakMode(NSLineBreakMode)
     /// Text base line offset (vertical)
     case baselineOffset(CGFloat)
-
-    /// Figma friendly case means that lineSpacing = lineHeight - font.lineHeight
-    /// This case provide possibility to set both `font` and `lineSpacing`
-    /// First parameter is Font and second parameter is lineHeight property from Figma
-    /// For more details see [#14](https://github.com/surfstudio/iOS-Utils/issues/14)
-    case lineHeight(CGFloat, font: UIFont)
+    /// Text line minimum and maximum height
+    case lineHeight(CGFloat)
 }
 
 // MARK: - Nested types
@@ -97,8 +93,8 @@ extension StringAttribute {
             return value
         case .aligment(let value):
             return value
-        case .lineHeight(let lineHeight, let font):
-            return lineHeight - font.lineHeight
+        case .lineHeight(let value):
+            return value
         case .crossOut(let style):
             return style.coreValue.rawValue
         case .lineBreakMode(let value):
@@ -142,12 +138,8 @@ public extension StringAttribute {
            let mutableParagraphStyle = value as? NSMutableParagraphStyle {
             stringAttributedArray.append(.aligment(mutableParagraphStyle.alignment))
             stringAttributedArray.append(.lineBreakMode(mutableParagraphStyle.lineBreakMode))
-
-            if let font = dictionary[.font] as? UIFont {
-                stringAttributedArray.append(.lineHeight(mutableParagraphStyle.lineSpacing, font: font))
-            } else {
-                stringAttributedArray.append(.lineSpacing(mutableParagraphStyle.lineSpacing))
-            }
+            stringAttributedArray.append(.lineHeight(mutableParagraphStyle.minimumLineHeight))
+            stringAttributedArray.append(.lineSpacing(mutableParagraphStyle.lineSpacing))
         }
 
         return stringAttributedArray
@@ -163,35 +155,17 @@ public extension String {
     }
 }
 
-// MARK: - Private array extension
-
-private extension Array where Element == StringAttribute {
-    func normalizedAttributes() -> [StringAttribute] {
-        var result = [StringAttribute](self)
-
-        self.forEach { item in
-            switch item {
-            case .lineHeight(_, let font):
-                result.append(.font(font))
-            default:
-                break
-            }
-        }
-
-        return result
-    }
-}
-
 // MARK: - Public array extension
 
 public extension Array where Element == StringAttribute {
     func toDictionary() -> [NSAttributedString.Key: Any] {
         var resultAttributes = [NSAttributedString.Key: Any]()
         let paragraph = NSMutableParagraphStyle()
-        for attribute in self.normalizedAttributes() {
+        for attribute in self {
             switch attribute {
-            case .lineHeight(let lineHeight, let font):
-                paragraph.lineSpacing = lineHeight - font.lineHeight
+            case .lineHeight(let lineHeight):
+                paragraph.minimumLineHeight = lineHeight
+                paragraph.maximumLineHeight = lineHeight
                 resultAttributes[attribute.attributeKey] = paragraph
             case .lineSpacing(let value):
                 paragraph.lineSpacing = value

--- a/Utils/Utils/String/String+Attributes.swift
+++ b/Utils/Utils/String/String+Attributes.swift
@@ -27,7 +27,7 @@ public enum StringAttribute {
     case lineBreakMode(NSLineBreakMode)
     /// Text base line offset (vertical)
     case baselineOffset(CGFloat)
-    /// Text line minimum and maximum height
+    /// Text line height
     case lineHeight(CGFloat)
 }
 
@@ -161,11 +161,16 @@ public extension Array where Element == StringAttribute {
     func toDictionary() -> [NSAttributedString.Key: Any] {
         var resultAttributes = [NSAttributedString.Key: Any]()
         let paragraph = NSMutableParagraphStyle()
+        let font = self.findFont()
         for attribute in self {
             switch attribute {
             case .lineHeight(let lineHeight):
-                paragraph.minimumLineHeight = lineHeight
-                paragraph.maximumLineHeight = lineHeight
+                if let font = font {
+                    paragraph.lineHeightMultiple = lineHeight / font.lineHeight
+                } else {
+                    paragraph.minimumLineHeight = lineHeight
+                    paragraph.maximumLineHeight = lineHeight
+                }
                 resultAttributes[attribute.attributeKey] = paragraph
             case .lineSpacing(let value):
                 paragraph.lineSpacing = value
@@ -181,5 +186,14 @@ public extension Array where Element == StringAttribute {
             }
         }
         return resultAttributes
+    }
+
+    private func findFont() -> UIFont? {
+        for value in self {
+            if case .font(let font) = value {
+                return font
+            }
+        }
+        return nil
     }
 }


### PR DESCRIPTION
# What is done

- высота теперь выставляется не через расстояние между строк и не зависит от шрифта. меняются параметры minLineHeight и maxLineHeight 

# What to look for

- если высота строки меньше высоты шрифта, то будет обрезание строк. 

# How to check

- установить в проект под из ветки (добавить в podfile следующую строку: 

>  pod 'SurfUtils/StringAttributes', :git => "https://github.com/surfstudio/iOS-Utils.git", :branch => 'IDPT-799-fix-string-attributes-lineHeight'

- вывести на экран несколько лейблов с разными параметрами .lineHeight(CGFloat) 